### PR TITLE
Feat(#7): Kakao 로그인을 위한 oAuth2 설정을 진행한다.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,11 @@ dependencies {
     // swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
 
+    // oauth 2.0
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+
+    // spring security
+    implementation("org.springframework.boot:spring-boot-starter-security")
 
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,9 +32,6 @@ dependencies {
     // oauth 2.0
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 
-    // spring security
-    implementation("org.springframework.boot:spring-boot-starter-security")
-
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/src/main/kotlin/com/zighang/core/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/zighang/core/config/security/SecurityConfig.kt
@@ -1,0 +1,23 @@
+package com.zighang.core.config.security
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig {
+
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .authorizeHttpRequests {
+                it.anyRequest().permitAll()
+            }
+
+        return http.build()
+    }
+}

--- a/src/main/kotlin/com/zighang/core/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/zighang/core/config/security/SecurityConfig.kt
@@ -1,4 +1,0 @@
-package com.zighang.core.config.security
-
-class SecurityConfig {
-}

--- a/src/main/kotlin/com/zighang/core/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/zighang/core/config/security/SecurityConfig.kt
@@ -1,0 +1,4 @@
+package com.zighang.core.config.security
+
+class SecurityConfig {
+}

--- a/src/main/kotlin/com/zighang/core/exception/GlobalErrorCode.kt
+++ b/src/main/kotlin/com/zighang/core/exception/GlobalErrorCode.kt
@@ -6,12 +6,13 @@ import org.springframework.http.HttpStatus
 enum class GlobalErrorCode(
     override val httpStatus: HttpStatus,
     override val message: String
-) : BaseErrorCode<RuntimeException> {
+) : BaseErrorCode<DomainException> {
 
     // 예시 에러 코드
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다.");
 
-    override fun toException(): RuntimeException {
-        return RuntimeException(message)
+
+    override fun toException(): DomainException {
+        return DomainException(message)
     }
 }

--- a/src/main/kotlin/com/zighang/core/exception/GlobalErrorCode.kt
+++ b/src/main/kotlin/com/zighang/core/exception/GlobalErrorCode.kt
@@ -13,6 +13,6 @@ enum class GlobalErrorCode(
 
 
     override fun toException(): DomainException {
-        return DomainException(message)
+        return DomainException(this)
     }
 }

--- a/src/main/kotlin/com/zighang/core/oauth/CustomOAuth2User.kt
+++ b/src/main/kotlin/com/zighang/core/oauth/CustomOAuth2User.kt
@@ -1,0 +1,29 @@
+package com.zighang.core.oauth
+
+import com.zighang.core.oauth.dto.UserDto
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.oauth2.core.user.OAuth2User
+
+class CustomOAuth2User(
+    private val userDto: UserDto
+) : OAuth2User {
+    override fun getName(): String {
+        return userDto.name
+    }
+
+    override fun getAttributes(): MutableMap<String, Any> {
+        return mutableMapOf()
+    }
+
+    override fun getAuthorities(): MutableCollection<out GrantedAuthority> {
+        return mutableListOf()
+    }
+
+    fun getEmail(): String {
+        return userDto.email ?: "";
+    }
+
+    fun getUserId(): Long {
+        return userDto.userId
+    }
+}

--- a/src/main/kotlin/com/zighang/core/oauth/dto/KaKaoResponse.kt
+++ b/src/main/kotlin/com/zighang/core/oauth/dto/KaKaoResponse.kt
@@ -1,0 +1,34 @@
+package com.zighang.core.oauth.dto
+
+import com.zighang.core.oauth.exception.OAuth2ErrorCode
+
+class KaKaoResponse(private val attributes : Map<String, Any>) : OAuth2Response {
+    override fun getProviderId(): String {
+        return attributes["id"].toString()
+    }
+
+    override fun getEmail(): String {
+        val kakaoAccount = attributes["kakao_account"] as? Map<*, *>
+
+        return kakaoAccount?.get("email")?.toString()
+            ?: throw OAuth2ErrorCode.CANNOT_FIND_EMAIL_IN_KAKAO.toException();
+    }
+
+    override fun getName(): String {
+        val properties = attributes["properties"] as? Map<*, *>
+        properties?.get("nickname")?.let {
+            return it.toString()
+        }
+
+        val kakaoAccount = attributes["kakao_account"] as? Map<*, *>
+        val profile = kakaoAccount?.get("profile") as? Map<*, *>
+        return profile?.get("nickname")?.toString()
+            ?: throw OAuth2ErrorCode.CANNOT_FIND_NICKNAME_IN_KAKAO.toException();
+    }
+
+    fun getProfileImage(): String? {
+        val kakaoAccount = attributes["kakao_account"] as? Map<*, *>
+        val profile = kakaoAccount?.get("profile") as? Map<*, *>
+        return profile?.get("profile_image_url") as? String
+    }
+}

--- a/src/main/kotlin/com/zighang/core/oauth/dto/OAuth2Response.kt
+++ b/src/main/kotlin/com/zighang/core/oauth/dto/OAuth2Response.kt
@@ -1,0 +1,9 @@
+package com.zighang.core.oauth.dto
+
+interface OAuth2Response {
+    fun getProviderId(): String
+
+    fun getEmail(): String
+
+    fun getName(): String
+}

--- a/src/main/kotlin/com/zighang/core/oauth/dto/UserDto.kt
+++ b/src/main/kotlin/com/zighang/core/oauth/dto/UserDto.kt
@@ -1,0 +1,15 @@
+package com.zighang.core.oauth.dto
+
+data class UserDto(
+    val registrationId: String,
+
+    val name: String,
+
+    val username: String,
+
+    val email: String? = null,
+
+    val profileImage: String? = null,
+
+    val userId: Long,
+)

--- a/src/main/kotlin/com/zighang/core/oauth/exception/OAuth2ErrorCode.kt
+++ b/src/main/kotlin/com/zighang/core/oauth/exception/OAuth2ErrorCode.kt
@@ -1,0 +1,19 @@
+package com.zighang.core.oauth.exception
+
+import com.zighang.core.exception.DomainException
+import com.zighang.core.exception.error.BaseErrorCode
+import org.springframework.http.HttpStatus
+
+enum class OAuth2ErrorCode (
+    override val httpStatus: HttpStatus,
+    override val message: String,
+): BaseErrorCode<DomainException> {
+
+    OAUTH2_PROVIDER_ERROR(HttpStatus.BAD_REQUEST, "oAuth2 제공자 이름이 잘못되었습니다."),
+    CANNOT_FIND_EMAIL_IN_KAKAO(HttpStatus.NOT_FOUND, "카카오 이메일 정보를 찾을 수 없습니다."),
+    CANNOT_FIND_NICKNAME_IN_KAKAO(HttpStatus.NOT_FOUND, "카카오 닉네임 정보를 찾을 수 없습니다.");
+
+    override fun toException(): DomainException {
+        return DomainException(message)
+    }
+}

--- a/src/main/kotlin/com/zighang/core/oauth/exception/OAuth2ErrorCode.kt
+++ b/src/main/kotlin/com/zighang/core/oauth/exception/OAuth2ErrorCode.kt
@@ -10,8 +10,10 @@ enum class OAuth2ErrorCode (
 ): BaseErrorCode<DomainException> {
 
     OAUTH2_PROVIDER_ERROR(HttpStatus.BAD_REQUEST, "oAuth2 제공자 이름이 잘못되었습니다."),
+    IS_NOT_OAUTH2_USER(HttpStatus.INTERNAL_SERVER_ERROR, "oAuth2 사용자가 아닙니다."),
     CANNOT_FIND_EMAIL_IN_KAKAO(HttpStatus.NOT_FOUND, "카카오 이메일 정보를 찾을 수 없습니다."),
-    CANNOT_FIND_NICKNAME_IN_KAKAO(HttpStatus.NOT_FOUND, "카카오 닉네임 정보를 찾을 수 없습니다.");
+    CANNOT_FIND_NICKNAME_IN_KAKAO(HttpStatus.NOT_FOUND, "카카오 닉네임 정보를 찾을 수 없습니다."),
+    OAUTH2_UNAUTHORIZED_ERROR(HttpStatus.FORBIDDEN, "인증이 완료되지 않았습니다.");
 
     override fun toException(): DomainException {
         return DomainException(message)

--- a/src/main/kotlin/com/zighang/core/oauth/exception/OAuth2ErrorCode.kt
+++ b/src/main/kotlin/com/zighang/core/oauth/exception/OAuth2ErrorCode.kt
@@ -13,9 +13,9 @@ enum class OAuth2ErrorCode (
     IS_NOT_OAUTH2_USER(HttpStatus.INTERNAL_SERVER_ERROR, "oAuth2 사용자가 아닙니다."),
     CANNOT_FIND_EMAIL_IN_KAKAO(HttpStatus.NOT_FOUND, "카카오 이메일 정보를 찾을 수 없습니다."),
     CANNOT_FIND_NICKNAME_IN_KAKAO(HttpStatus.NOT_FOUND, "카카오 닉네임 정보를 찾을 수 없습니다."),
-    OAUTH2_UNAUTHORIZED_ERROR(HttpStatus.FORBIDDEN, "인증이 완료되지 않았습니다.");
+    OAUTH2_UNAUTHORIZED_ERROR(HttpStatus.FORBIDDEN, "해당 자원에 접근할 권한이 없습니다.");
 
     override fun toException(): DomainException {
-        return DomainException(message)
+        return DomainException(this)
     }
 }

--- a/src/main/kotlin/com/zighang/core/oauth/handler/CustomOAuth2AccessDeniedHandler.kt
+++ b/src/main/kotlin/com/zighang/core/oauth/handler/CustomOAuth2AccessDeniedHandler.kt
@@ -1,0 +1,47 @@
+package com.zighang.core.oauth.handler
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.zighang.core.oauth.exception.OAuth2ErrorCode
+import com.zighang.core.presentation.ErrorResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.web.access.AccessDeniedHandler
+
+class CustomOAuth2AccessDeniedHandler(
+    private val objectMapper : ObjectMapper
+) : AccessDeniedHandler {
+
+    private val logger = LoggerFactory.getLogger(CustomOAuth2AccessDeniedHandler::class.java)
+
+    override fun handle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        accessDeniedException: AccessDeniedException
+    ) {
+
+        if(response.isCommitted) return;
+
+
+        val httpStatusForResponse = OAuth2ErrorCode.OAUTH2_UNAUTHORIZED_ERROR.httpStatus
+        val customErrorCodeName = "ACCESS_DENIED_ERROR"
+        val customErrorMessage = "해당 자원에 접근할 권한이 없습니다."
+
+        val errorResponse = ErrorResponse(
+            statusCode = HttpStatus.FORBIDDEN.value(),
+            code = customErrorCodeName,
+            message = customErrorMessage,
+        )
+        response.status = httpStatusForResponse.value() // 403 Forbidden
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = Charsets.UTF_8.name()
+
+        val responseJson = objectMapper.writeValueAsString(errorResponse)
+        response.writer.write(responseJson)
+
+        logger.error("Access Denined : ${accessDeniedException.message}")
+    }
+}

--- a/src/main/kotlin/com/zighang/core/oauth/handler/CustomOAuth2AccessDeniedHandler.kt
+++ b/src/main/kotlin/com/zighang/core/oauth/handler/CustomOAuth2AccessDeniedHandler.kt
@@ -6,7 +6,6 @@ import com.zighang.core.presentation.ErrorResponse
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.LoggerFactory
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.web.access.AccessDeniedHandler
@@ -26,16 +25,15 @@ class CustomOAuth2AccessDeniedHandler(
         if(response.isCommitted) return;
 
 
-        val httpStatusForResponse = OAuth2ErrorCode.OAUTH2_UNAUTHORIZED_ERROR.httpStatus
-        val customErrorCodeName = "ACCESS_DENIED_ERROR"
-        val customErrorMessage = "해당 자원에 접근할 권한이 없습니다."
+        val httpStatusForResponse = OAuth2ErrorCode.OAUTH2_UNAUTHORIZED_ERROR
 
         val errorResponse = ErrorResponse(
-            statusCode = HttpStatus.FORBIDDEN.value(),
-            code = customErrorCodeName,
-            message = customErrorMessage,
+            statusCode = httpStatusForResponse.httpStatus.value(),
+            code = httpStatusForResponse.httpStatus.name,
+            message = httpStatusForResponse.message,
         )
-        response.status = httpStatusForResponse.value() // 403 Forbidden
+
+        response.status = httpStatusForResponse.httpStatus.value()
         response.contentType = MediaType.APPLICATION_JSON_VALUE
         response.characterEncoding = Charsets.UTF_8.name()
 

--- a/src/main/kotlin/com/zighang/core/oauth/handler/CustomOAuth2SuccessHandler.kt
+++ b/src/main/kotlin/com/zighang/core/oauth/handler/CustomOAuth2SuccessHandler.kt
@@ -1,0 +1,30 @@
+package com.zighang.core.oauth.handler
+
+import com.zighang.core.oauth.CustomOAuth2User
+import com.zighang.core.oauth.exception.OAuth2ErrorCode
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler
+
+class CustomOAuth2SuccessHandler(
+    // token, repository, redirectUrl
+    private val redirectUrl : String
+) : SimpleUrlAuthenticationSuccessHandler() {
+
+    override fun onAuthenticationSuccess(
+        request: HttpServletRequest?,
+        response: HttpServletResponse?,
+        authentication: Authentication
+    ) {
+        val principal = authentication.principal
+
+        if(principal !is CustomOAuth2User) {
+            throw OAuth2ErrorCode.IS_NOT_OAUTH2_USER.toException()
+        }
+
+        // token 설정 해주기
+
+        response?.sendRedirect(redirectUrl)
+    }
+}

--- a/src/main/kotlin/com/zighang/core/oauth/service/CustomOAuth2Service.kt
+++ b/src/main/kotlin/com/zighang/core/oauth/service/CustomOAuth2Service.kt
@@ -1,0 +1,27 @@
+package com.zighang.core.oauth.service
+
+import com.zighang.core.oauth.dto.KaKaoResponse
+import com.zighang.core.oauth.exception.OAuth2ErrorCode
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Service
+
+@Service
+class CustomOAuth2Service(
+    // TODO : MemberRepository 채워넣기
+) : DefaultOAuth2UserService() {
+
+    override fun loadUser(oAuth2UserRequest: OAuth2UserRequest) : OAuth2User {
+        val oAuth2User = super.loadUser(oAuth2UserRequest)
+
+        val registrationId = oAuth2UserRequest.clientRegistration.registrationId
+        val oAuth2UserResponse = when (registrationId) {
+            "kakao" -> KaKaoResponse(oAuth2User.attributes)
+            else -> throw OAuth2ErrorCode.OAUTH2_PROVIDER_ERROR.toException()
+        }
+
+        // TODO : 이메일로 유저 찾아서 없으면 가입시키고, 있으면 로그인 진행
+        return oAuth2User
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 카카오 로그인 기능 구현을 위한 service, filter 로직 구현
- custom oAuth2 객체를 사용한 유저 객체 임시 생성

---

## ✏️ 관련 이슈
#7 

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 카카오 OAuth2 응답 어댑터 및 사용자 DTO/어댑터 추가, OAuth2 사용자 표현(CustomOAuth2User) 도입
  - 로그인 성공 시 지정된 URL로 리다이렉트 구현
  - 접근 거부 시 표준 JSON 오류 응답(403) 제공

- Refactor
  - 전역 오류 코드가 도메인 예외(DomainException)로 통합되어 오류 처리 일관성 향상

- Chores
  - OAuth2 클라이언트 라이브러리 추가 및 보안 설정(시큐리티 필터 체인)과 OAuth2 서비스/핸들러 기본 구성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->