### PR TITLE
Feat(#10): 카카오 로그인 DB 및 토큰 연동

### DIFF
--- a/src/main/kotlin/com/zighang/core/infrastructure/CustomUserDetails.kt
+++ b/src/main/kotlin/com/zighang/core/infrastructure/CustomUserDetails.kt
@@ -1,20 +1,18 @@
 package com.zighang.core.infrastructure
 
+import com.zighang.member.entity.Member
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 
 class CustomUserDetails(
-    // Todo 멤버 테이블 확정되면 주석 해제
-//    private val member: Member,
+    private val member: Member,
 ) : UserDetails {
     fun getId(): Long {
-//        return member.id
-        return 1L;
+        return member.id
     }
     override fun getAuthorities(): MutableCollection<out GrantedAuthority> {
-        return mutableListOf(SimpleGrantedAuthority("ROLE_ADMIN"))
-//        return mutableListOf(SimpleGrantedAuthority("ROLE_${member.Role.name}"))
+        return mutableListOf(SimpleGrantedAuthority("ROLE_${member.role.name}"))
     }
 
     override fun getPassword(): String {

--- a/src/main/kotlin/com/zighang/core/infrastructure/CustomUserDetails.kt
+++ b/src/main/kotlin/com/zighang/core/infrastructure/CustomUserDetails.kt
@@ -14,7 +14,7 @@ class CustomUserDetails(
     }
     override fun getAuthorities(): MutableCollection<out GrantedAuthority> {
         return mutableListOf(SimpleGrantedAuthority("ROLE_ADMIN"))
-//        return mutableListOf(SimpleGrantedAuthority("ROLE_${member.role.name}"))
+//        return mutableListOf(SimpleGrantedAuthority("ROLE_${member.Role.name}"))
     }
 
     override fun getPassword(): String {

--- a/src/main/kotlin/com/zighang/core/jwt/TokenService.kt
+++ b/src/main/kotlin/com/zighang/core/jwt/TokenService.kt
@@ -14,9 +14,14 @@ class TokenService(
     val AUDIENCE = jwtProperties.audience
     val SECRET_KEY = Keys.hmacShaKeyFor(jwtProperties.secretKey.toByteArray(Charsets.UTF_8))
     val ACCESS_TOKEN_EXPIRATION = jwtProperties.accessTokenExpiration
+    val REFRESH_TOKEN_EXPIRATION = jwtProperties.refreshTokenExpiration
 
     fun provideAccessToken(userId: Long, role: String): String {
         return createToken(userId, role, ACCESS_TOKEN_EXPIRATION, Type.ACCESS)
+    }
+
+    fun provideRefreshToken(userId: Long, role: String): String {
+        return createToken(userId, role, REFRESH_TOKEN_EXPIRATION, Type.REFRESH)
     }
 
     fun getMemberIdFromToken(token: String): Long {
@@ -46,7 +51,7 @@ class TokenService(
             .audience().add(AUDIENCE).and()
             .subject(userId.toString())
             .claim("type", type.name)
-            .claim("role", role)
+            .claim("Role", role)
             .issuedAt(Date())
             .expiration(expiryDate)
             .signWith(SECRET_KEY)

--- a/src/main/kotlin/com/zighang/core/oauth/dto/TokenResponseDto.kt
+++ b/src/main/kotlin/com/zighang/core/oauth/dto/TokenResponseDto.kt
@@ -1,11 +1,9 @@
 package com.zighang.core.oauth.dto
 
-import com.zighang.member.entity.Role
-
 class TokenResponseDto(
     val accessToken: String,
     val refreshToken: String,
     val name: String,
-    val role: Role
+    val role: String,
 ) {
 }

--- a/src/main/kotlin/com/zighang/core/oauth/dto/TokenResponseDto.kt
+++ b/src/main/kotlin/com/zighang/core/oauth/dto/TokenResponseDto.kt
@@ -1,0 +1,11 @@
+package com.zighang.core.oauth.dto
+
+import com.zighang.member.entity.Role
+
+class TokenResponseDto(
+    val accessToken: String,
+    val refreshToken: String,
+    val name: String,
+    val role: Role
+) {
+}

--- a/src/main/kotlin/com/zighang/core/oauth/handler/CustomOAuth2SuccessHandler.kt
+++ b/src/main/kotlin/com/zighang/core/oauth/handler/CustomOAuth2SuccessHandler.kt
@@ -36,18 +36,18 @@ class CustomOAuth2SuccessHandler(
         }
 
         val userId = principal.getUserId()
-        val role = principal.authorities.firstOrNull()?.authority
-        val accessToken = tokenService.provideAccessToken(userId, role ?: "GUEST")
-        val refreshToken = tokenService.provideRefreshToken(userId, role ?: "GUEST")
-
         val existingMember = memberRepository.findByEmail(principal.getEmail())
+        val roleName = (existingMember?.role ?: com.zighang.member.entity.Role.GUEST).name
+        val accessToken = tokenService.provideAccessToken(userId, roleName)
+        val refreshToken = tokenService.provideRefreshToken(userId, roleName)
+
 
         val tokenDto = existingMember?.let {
             TokenResponseDto(
                 accessToken = accessToken,
                 refreshToken = refreshToken,
                 name = it.name,
-                role = it.role,
+                role = roleName,
             )
         }
 

--- a/src/main/kotlin/com/zighang/core/oauth/handler/CustomOAuth2SuccessHandler.kt
+++ b/src/main/kotlin/com/zighang/core/oauth/handler/CustomOAuth2SuccessHandler.kt
@@ -1,19 +1,27 @@
 package com.zighang.core.oauth.handler
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.zighang.core.jwt.TokenService
 import com.zighang.core.oauth.CustomOAuth2User
+import com.zighang.core.oauth.dto.TokenResponseDto
 import com.zighang.core.oauth.exception.OAuth2ErrorCode
+import com.zighang.member.repository.MemberRepository
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.security.core.Authentication
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler
 import org.springframework.stereotype.Component
 
 @Component
 class CustomOAuth2SuccessHandler(
-    // token, repository, redirectUrl
+    private val tokenService: TokenService,
+    private val memberRepository: MemberRepository,
     @Value("\${oauth2.redirect-url}")
     private val redirectUrl: String,
+    private val objectMapper: ObjectMapper
 ) : SimpleUrlAuthenticationSuccessHandler() {
 
     override fun onAuthenticationSuccess(
@@ -27,6 +35,27 @@ class CustomOAuth2SuccessHandler(
             throw OAuth2ErrorCode.IS_NOT_OAUTH2_USER.toException()
         }
 
-        // token 설정 해주기
+        val userId = principal.getUserId()
+        val role = principal.authorities.firstOrNull()?.authority
+        val accessToken = tokenService.provideAccessToken(userId, role ?: "GUEST")
+        val refreshToken = tokenService.provideRefreshToken(userId, role ?: "GUEST")
+
+        val existingMember = memberRepository.findByEmail(principal.getEmail())
+
+        val tokenDto = existingMember?.let {
+            TokenResponseDto(
+                accessToken = accessToken,
+                refreshToken = refreshToken,
+                name = it.name,
+                role = it.role,
+            )
+        }
+
+        response?.apply {
+            status = HttpStatus.OK.value()
+            contentType = MediaType.APPLICATION_JSON_VALUE
+            characterEncoding = Charsets.UTF_8.name()
+            writer.write(objectMapper.writeValueAsString(tokenDto))
+        }
     }
 }

--- a/src/main/kotlin/com/zighang/core/oauth/service/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/zighang/core/oauth/service/CustomOAuth2UserService.kt
@@ -42,14 +42,12 @@ class CustomOAuth2UserService(
         val existingMember = memberRepository.findByEmail(email)
 
         if(existingMember != null) {
-            println("name = ${existingMember.name} 로그인 완료")
             return CustomOAuth2User(userDto)
         } else {
             val newMember = Member.create(
                 name, email, profileImage
             )
             memberRepository.save(newMember)
-            println("name = ${newMember.name} 가입 완료")
         }
 
         return CustomOAuth2User(userDto)

--- a/src/main/kotlin/com/zighang/member/entity/Member.kt
+++ b/src/main/kotlin/com/zighang/member/entity/Member.kt
@@ -18,6 +18,10 @@ class Member (
 
     @Column(name = "profile_image_url")
     var profileImageUrl: String?,
+
+    @Column(name = "role", nullable = false)
+    @Enumerated(EnumType.STRING)
+    var role: Role,
 ) : BaseEntity() {
 
     companion object {
@@ -25,11 +29,13 @@ class Member (
             name: String,
             email: String,
             profileImageUrl: String?,
+            role: Role = Role.GUEST,
         ): Member {
             return Member(
                 name = name,
                 email = email,
                 profileImageUrl = profileImageUrl ?: "",
+                role = role
             )
         }
     }

--- a/src/main/kotlin/com/zighang/member/entity/Role.kt
+++ b/src/main/kotlin/com/zighang/member/entity/Role.kt
@@ -1,0 +1,6 @@
+package com.zighang.member.entity
+
+enum class Role {
+    GUEST,
+    MEMBER
+}

--- a/src/main/kotlin/com/zighang/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/zighang/member/repository/MemberRepository.kt
@@ -1,0 +1,9 @@
+package com.zighang.member.repository
+
+import com.zighang.member.entity.Member
+import org.springframework.data.repository.CrudRepository
+
+interface MemberRepository : CrudRepository<Member, Long> {
+
+    fun findByEmail(email: String): Member?
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- DB 및 토큰 연동을 통한 로그인 로직 완료

---

## ✏️ 관련 이슈
#10 

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - OAuth 로그인 성공 시 액세스/리프레시 토큰을 발급하고, 사용자 이름·역할과 함께 JSON으로 응답합니다.
  - 리프레시 토큰 지원으로 세션 연장을 사용할 수 있습니다.
  - 첫 소셜 로그인 시 프로필 정보를 기반으로 회원이 자동 생성됩니다.
  - 역할 체계(게스트, 멤버)를 도입해 사용자 권한을 구분합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->