### PR TITLE
Feat : 공고 스크랩 및 대시보드 형태로 조회할 수 있도록 기능을 구현한다.

### DIFF
--- a/src/main/kotlin/com/zighang/core/application/ObjectStorageService.kt
+++ b/src/main/kotlin/com/zighang/core/application/ObjectStorageService.kt
@@ -10,6 +10,8 @@ import io.jsonwebtoken.io.IOException
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 import java.util.*
 
 
@@ -89,4 +91,14 @@ class ObjectStorageService(
         require(idx != -1) { throw IllegalArgumentException("잘못된 URL 형식입니다: $url") }
         return url.substring(idx + 5)
     }
+
+    fun extractOriginalFilenameFromS3(s3KeyOrUrl: String?): String? =
+        s3KeyOrUrl
+            ?.substringAfterLast('/')   // 마지막 세그먼트
+            ?.substringBefore('?')      // 쿼리 제거
+            ?.substringAfter('_')       // uuid_ 다음 부분(없으면 원문 그대로)
+            ?.let {
+                runCatching { URLDecoder.decode(it, StandardCharsets.UTF_8) }.getOrNull() ?: it
+            }
+
 }

--- a/src/main/kotlin/com/zighang/core/exception/GlobalErrorCode.kt
+++ b/src/main/kotlin/com/zighang/core/exception/GlobalErrorCode.kt
@@ -16,7 +16,7 @@ enum class GlobalErrorCode(
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
     FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다."),
     NOT_EXIST_SCRAP(HttpStatus.BAD_REQUEST, "해당 스크랩 공고가 존재하지 않습니다."),
-    NOT_EXIST_JOB_POSTING(HttpStatus.BAD_REQUEST, "해당 공고를 찾을 수 없습니다.");
+    NOT_EXIST_JOB_POSTING(HttpStatus.BAD_REQUEST, "해당 공고를 찾을 수 없습니다."),
     CLOVA_API_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "클로바 API 연결에 실패했습니다."),
     NOT_CONVERT_JSON_TO_OBJECT(HttpStatus.INTERNAL_SERVER_ERROR, "JSON 변환에 실패했습니다.");
 

--- a/src/main/kotlin/com/zighang/core/exception/GlobalErrorCode.kt
+++ b/src/main/kotlin/com/zighang/core/exception/GlobalErrorCode.kt
@@ -14,7 +14,9 @@ enum class GlobalErrorCode(
     NOT_EXIST_MEMBER(HttpStatus.BAD_REQUEST, "해당 멤버가 존재하지 않습니다."),
     NOT_EXIST_ONBOARDING(HttpStatus.BAD_REQUEST, "온보딩 데이터가 존재하지 않습니다"),
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
-    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다.");
+    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다."),
+    NOT_EXIST_SCRAP(HttpStatus.BAD_REQUEST, "해당 스크랩 공고가 존재하지 않습니다."),
+    NOT_EXIST_JOB_POSTING(HttpStatus.BAD_REQUEST, "해당 공고를 찾을 수 없습니다.");
 
 
     override fun toException(): DomainException {

--- a/src/main/kotlin/com/zighang/core/presentation/PageResponse.kt
+++ b/src/main/kotlin/com/zighang/core/presentation/PageResponse.kt
@@ -1,0 +1,40 @@
+package com.zighang.core.presentation
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.data.domain.Page
+import java.time.LocalDateTime
+
+class PageResponse<T>(
+    @Schema(description = "페이지 데이터")
+    val data: List<T>,
+
+    @Schema(description = "전체 페이지 수")
+    val totalPages: Int,
+
+    @Schema(description = "마지막 페이지 여부")
+    val last: Boolean,
+
+    @Schema(description = "전체 데이터 수")
+    val totalElements: Long,
+
+    @Schema(description = "현재 페이지 (0-based)")
+    val page: Int,
+
+    @Schema(description = "페이지 크기")
+    val size: Int
+) : BaseResponse(
+    success = true,
+    timestamp = LocalDateTime.now()
+) {
+    companion object {
+        fun <T> from(page: Page<T>): PageResponse<T> =
+            PageResponse(
+                data = page.content,
+                totalPages = page.totalPages,
+                last = page.isLast,
+                totalElements = page.totalElements,
+                page = page.number,
+                size = page.size
+            )
+    }
+}

--- a/src/main/kotlin/com/zighang/memo/repository/MemoRepository.kt
+++ b/src/main/kotlin/com/zighang/memo/repository/MemoRepository.kt
@@ -6,4 +6,9 @@ import org.springframework.data.repository.CrudRepository
 interface MemoRepository : CrudRepository<Memo, Long> {
 
     fun findByPostingIdAndMemberId(postingId: Long, memberId: Long): Memo?
+
+    fun findAllByPostingIdInAndMemberId(
+        postingIds: Collection<Long>,
+        memberId: Long
+    ): List<Memo>
 }

--- a/src/main/kotlin/com/zighang/scrap/dto/request/UpsertScrapRequest.kt
+++ b/src/main/kotlin/com/zighang/scrap/dto/request/UpsertScrapRequest.kt
@@ -1,0 +1,14 @@
+package com.zighang.scrap.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class UpsertScrapRequest(
+    @Schema(description = "스크랩 식별자(만약 새로 만드는 단계면 null값으로)", example = "1")
+    val scrapId : Long?,
+    @Schema(description = "공고 식별자", example = "1")
+    val jobPostingId : Long,
+    @Schema(description = "이력서 url", example = "http://url")
+    val resumeUrl : String?,
+    @Schema(description = "포트폴리오 url",  example = "http://url")
+    val portfolioUrl : String?
+)

--- a/src/main/kotlin/com/zighang/scrap/dto/response/DashboardResponse.kt
+++ b/src/main/kotlin/com/zighang/scrap/dto/response/DashboardResponse.kt
@@ -1,0 +1,29 @@
+package com.zighang.scrap.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class DashboardResponse(
+    @Schema(description = "스크랩 식별자", example = "1")
+    val scrapId: Long,
+
+    @Schema(description = "메모 식별자", example = "1")
+    val memoId : Long?,
+
+    @Schema(description = "공고 정보")
+    val jobPostingResponse : JobPostingResponse,
+
+    @Schema(description = "이력서 정보")
+    val fileResponse : FileResponse,
+
+    @Schema(description = "포트폴리오 정보")
+    val portfolioResponse : FileResponse
+) {
+    companion object {
+        fun create(scrapId: Long, memoId: Long?, jobPostingResponse: JobPostingResponse,
+                   fileResponse : FileResponse, portfolioResponse : FileResponse) : DashboardResponse{
+            return DashboardResponse(
+                scrapId, memoId, jobPostingResponse, fileResponse, portfolioResponse
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/zighang/scrap/dto/response/FileResponse.kt
+++ b/src/main/kotlin/com/zighang/scrap/dto/response/FileResponse.kt
@@ -1,0 +1,16 @@
+package com.zighang.scrap.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class FileResponse(
+    @Schema(description = "파일 url", example = "https://s3:resume-233333")
+    val fileUrl : String?,
+    @Schema(description = "파일 원본 이름", example = "OOO파일")
+    val originalFileName : String?,
+) {
+    companion object {
+        fun create(fileUrl: String?, originalFileName: String?) : FileResponse{
+            return FileResponse(fileUrl, originalFileName)
+        }
+    }
+}

--- a/src/main/kotlin/com/zighang/scrap/dto/response/JobPostingResponse.kt
+++ b/src/main/kotlin/com/zighang/scrap/dto/response/JobPostingResponse.kt
@@ -38,7 +38,7 @@ data class JobPostingResponse(
             if (date == null) return null
             val today = LocalDate.now()
             val targetDate = date.toLocalDate()
-            return ChronoUnit.DAYS.between(today, targetDate)*-1
+            return ChronoUnit.DAYS.between(today, targetDate)
         }
     }
 

--- a/src/main/kotlin/com/zighang/scrap/dto/response/JobPostingResponse.kt
+++ b/src/main/kotlin/com/zighang/scrap/dto/response/JobPostingResponse.kt
@@ -1,0 +1,46 @@
+package com.zighang.scrap.dto.response
+
+import com.zighang.jobposting.entity.JobPosting
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+data class JobPostingResponse(
+    @Schema(description = "공고 id", example = "1")
+    val postingId : Long,
+    @Schema(description = "공고 타이틀", example = "OOO 공고")
+    val title : String?,
+    @Schema(description = "서류 마감일", example = "2025-07-20 00:05:00.000000")
+    val expiredDate : LocalDateTime?,
+    @Schema(description = "D-DAY", example = "3")
+    val dDay : Long?,
+    @Schema(description = "자격요건", example = "2년이상의 프론트 실무 경력 보유자")
+    val qualification : String?,
+    @Schema(description = "우대사항", example = "git을 활용한 형상관리 경험")
+    val preferentialTreatment : String?
+) {
+    companion object{
+        fun create(
+            jobPosting: JobPosting
+        ) : JobPostingResponse {
+            return JobPostingResponse(
+                jobPosting.id!!,
+                jobPosting.title,
+                jobPosting.expiredDate,
+                computeDday(jobPosting.expiredDate),
+                jobPosting.qualification,
+                jobPosting.preferentialTreatment
+            )
+        }
+
+        private fun computeDday(date : LocalDateTime?) : Long?{
+            if (date == null) return null
+            val today = LocalDate.now()
+            val targetDate = date.toLocalDate()
+            return ChronoUnit.DAYS.between(today, targetDate)*-1
+        }
+    }
+
+
+}

--- a/src/main/kotlin/com/zighang/scrap/entity/Scrap.kt
+++ b/src/main/kotlin/com/zighang/scrap/entity/Scrap.kt
@@ -8,7 +8,7 @@ import jakarta.persistence.*
 class Scrap(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0L,
+    var id: Long = 0L,
 
     @Column(name = "posting_id")
     var jobPostingId: Long,
@@ -16,10 +16,10 @@ class Scrap(
     @Column(name = "member_id")
     val memberId : Long,
 
-    @Column(name = "resume_url")
+    @Column(name = "resume_url", length = 1024)
     var resumeUrl : String?,
 
-    @Column(name = "portfolio_url")
+    @Column(name = "portfolio_url", length = 1024)
     var portfolioUrl : String?
 ) : BaseEntity() {
     companion object {

--- a/src/main/kotlin/com/zighang/scrap/entity/Scrap.kt
+++ b/src/main/kotlin/com/zighang/scrap/entity/Scrap.kt
@@ -1,0 +1,42 @@
+package com.zighang.scrap.entity
+
+import com.zighang.core.infrastructure.jpa.shared.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "scrap")
+class Scrap(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(name = "posting_id")
+    var jobPostingId: Long,
+
+    @Column(name = "member_id")
+    val memberId : Long,
+
+    @Column(name = "resume_url")
+    var resumeUrl : String?,
+
+    @Column(name = "portfolio_url")
+    var portfolioUrl : String?
+) : BaseEntity() {
+    companion object {
+        fun create(jobPostingId: Long, memberId: Long,
+                   resumeUrl: String?, portfolioUrl: String?) : Scrap {
+            return Scrap(
+                jobPostingId = jobPostingId,
+                memberId = memberId,
+                resumeUrl = resumeUrl,
+                portfolioUrl = portfolioUrl
+            )
+        }
+    }
+
+    fun update(postingId: Long, resumeUrl: String?, portfolioUrl: String?) {
+        this.jobPostingId = postingId
+        this.resumeUrl = resumeUrl
+        this.portfolioUrl = portfolioUrl
+    }
+}

--- a/src/main/kotlin/com/zighang/scrap/presentation/ScrapController.kt
+++ b/src/main/kotlin/com/zighang/scrap/presentation/ScrapController.kt
@@ -19,7 +19,7 @@ class ScrapController(
     private val scrapService: ScrapService
 ) : ScrapSwagger{
 
-    @PostMapping("/{postingId}")
+    @PostMapping
     override fun doScrap(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails,
         @RequestBody upsertScrapRequest: UpsertScrapRequest

--- a/src/main/kotlin/com/zighang/scrap/presentation/ScrapController.kt
+++ b/src/main/kotlin/com/zighang/scrap/presentation/ScrapController.kt
@@ -1,0 +1,49 @@
+package com.zighang.scrap.presentation
+
+import com.zighang.core.infrastructure.CustomUserDetails
+import com.zighang.core.presentation.PageResponse
+import com.zighang.core.presentation.RestResponse
+import com.zighang.scrap.dto.request.UpsertScrapRequest
+import com.zighang.scrap.dto.response.DashboardResponse
+import com.zighang.scrap.presentation.swagger.ScrapSwagger
+import com.zighang.scrap.service.ScrapService
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/scrap")
+@Tag(name = "Scrap", description = "스크랩 관련 API")
+class ScrapController(
+    private val scrapService: ScrapService
+) : ScrapSwagger{
+
+    @PostMapping("/{postingId}")
+    override fun doScrap(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @RequestBody upsertScrapRequest: UpsertScrapRequest
+    ): ResponseEntity<RestResponse<Boolean>> {
+        scrapService.upsert(customUserDetails, upsertScrapRequest)
+        return ResponseEntity.ok(
+            RestResponse<Boolean>(
+                true
+            )
+        )
+    }
+
+    @GetMapping
+    override fun getScrap(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @RequestParam(defaultValue = "1", name = "page") page : Int,
+        @RequestParam(defaultValue = "10", name = "size") size : Int
+    )
+    : ResponseEntity<PageResponse<DashboardResponse>> {
+        val safePage = if (page < 1) 0 else page - 1
+        return ResponseEntity.ok(
+            PageResponse.from(scrapService.getScrap(safePage, size, customUserDetails))
+        )
+    }
+
+
+}

--- a/src/main/kotlin/com/zighang/scrap/presentation/swagger/ScrapSwagger.kt
+++ b/src/main/kotlin/com/zighang/scrap/presentation/swagger/ScrapSwagger.kt
@@ -1,0 +1,36 @@
+package com.zighang.scrap.presentation.swagger
+
+import com.zighang.core.infrastructure.CustomUserDetails
+import com.zighang.core.presentation.PageResponse
+import com.zighang.core.presentation.RestResponse
+import com.zighang.scrap.dto.request.UpsertScrapRequest
+import com.zighang.scrap.dto.response.DashboardResponse
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
+
+interface ScrapSwagger {
+    @Operation(
+        summary = "스크랩 수행",
+        description = "스크랩을 수행합니다.",
+        operationId = "/scrap/{postingId}",
+    )
+    fun doScrap(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @RequestBody upsertScrapRequest: UpsertScrapRequest
+    ) : ResponseEntity<RestResponse<Boolean>>
+
+    @Operation(
+        summary = "대시보드 조회",
+        description = "스크랩을 대시보드 형태로 조회합니다.",
+        operationId = "/scrap/dashboard",
+    )
+    fun getScrap(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @RequestParam(name = "page", defaultValue = "1") page : Int,
+        @RequestParam(name = "size", defaultValue = "10") size : Int,
+    ) : ResponseEntity<PageResponse<DashboardResponse>>
+}

--- a/src/main/kotlin/com/zighang/scrap/repository/ScrapRepository.kt
+++ b/src/main/kotlin/com/zighang/scrap/repository/ScrapRepository.kt
@@ -1,8 +1,10 @@
 package com.zighang.scrap.repository
 
 import com.zighang.scrap.entity.Scrap
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface ScrapRepository : JpaRepository<Scrap, Long> {
-    fun findAllByMemberId(memberId : Long) : List<Scrap>
+    fun findAllByMemberId(memberId : Long, pageable: Pageable) : Page<Scrap>
 }

--- a/src/main/kotlin/com/zighang/scrap/repository/ScrapRepository.kt
+++ b/src/main/kotlin/com/zighang/scrap/repository/ScrapRepository.kt
@@ -1,0 +1,8 @@
+package com.zighang.scrap.repository
+
+import com.zighang.scrap.entity.Scrap
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ScrapRepository : JpaRepository<Scrap, Long> {
+    fun findAllByMemberId(memberId : Long) : List<Scrap>
+}

--- a/src/main/kotlin/com/zighang/scrap/service/ScrapService.kt
+++ b/src/main/kotlin/com/zighang/scrap/service/ScrapService.kt
@@ -5,6 +5,7 @@ import com.zighang.core.exception.DomainException
 import com.zighang.core.exception.GlobalErrorCode
 import com.zighang.core.infrastructure.CustomUserDetails
 import com.zighang.jobposting.repository.JobPostingRepository
+import com.zighang.memo.entity.Memo
 import com.zighang.memo.repository.MemoRepository
 import com.zighang.scrap.dto.request.UpsertScrapRequest
 import com.zighang.scrap.dto.response.DashboardResponse
@@ -65,7 +66,9 @@ class ScrapService(
             scrapPage.content.map { it.jobPostingId }.toSet()
         ).associateBy { it.id!! }
         val postingIds = postingMap.keys
-        val memoMap = memoRepository.findAllByPostingIdInAndMemberId(postingIds, memberId)
+        val memoMap : Map<Long, Memo> =
+            if (postingIds.isEmpty()) emptyMap()
+            else memoRepository.findAllByPostingIdInAndMemberId(postingIds, memberId)
             .associateBy { it.postingId }
         val dashboards = scrapPage.content.map { s ->
             val posting = postingMap[s.jobPostingId]

--- a/src/main/kotlin/com/zighang/scrap/service/ScrapService.kt
+++ b/src/main/kotlin/com/zighang/scrap/service/ScrapService.kt
@@ -1,0 +1,89 @@
+package com.zighang.scrap.service
+
+import com.zighang.core.application.ObjectStorageService
+import com.zighang.core.exception.DomainException
+import com.zighang.core.exception.GlobalErrorCode
+import com.zighang.core.infrastructure.CustomUserDetails
+import com.zighang.jobposting.repository.JobPostingRepository
+import com.zighang.memo.repository.MemoRepository
+import com.zighang.scrap.dto.request.UpsertScrapRequest
+import com.zighang.scrap.dto.response.DashboardResponse
+import com.zighang.scrap.dto.response.FileResponse
+import com.zighang.scrap.dto.response.JobPostingResponse
+import com.zighang.scrap.entity.Scrap
+import com.zighang.scrap.repository.ScrapRepository
+import lombok.extern.slf4j.Slf4j
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Slf4j
+class ScrapService(
+    private val scrapRepository: ScrapRepository,
+    private val jobPostingRepository: JobPostingRepository,
+    private val memoRepository: MemoRepository,
+    private val objectStorageService: ObjectStorageService
+) {
+    @Transactional
+    fun upsert(customUserDetails: CustomUserDetails, upsertScrapRequest: UpsertScrapRequest) : Scrap? {
+        jobPostingRepository.findById(upsertScrapRequest.jobPostingId)
+            .orElseThrow{DomainException(GlobalErrorCode.NOT_EXIST_JOB_POSTING)}
+        return upsertScrapRequest.scrapId?.let {
+            scrapId -> getById(scrapId).apply {
+                jobPostingId = upsertScrapRequest.jobPostingId
+                resumeUrl = upsertScrapRequest.resumeUrl
+                portfolioUrl = upsertScrapRequest.portfolioUrl
+            }.let {
+                savedScrap -> save(savedScrap)
+            }
+        } ?: save(
+            Scrap.create(
+                upsertScrapRequest.jobPostingId,
+                customUserDetails.getId(),
+                upsertScrapRequest.resumeUrl,
+                upsertScrapRequest.portfolioUrl
+            )
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getScrap(page : Int, size : Int, customUserDetails: CustomUserDetails) : Page<DashboardResponse> {
+        val scrapList = scrapRepository.findAllByMemberId(customUserDetails.getId())
+        val dashboardList = scrapList.map { s ->
+            val posting = jobPostingRepository.findById(s.jobPostingId).get()
+            val memoId = memoRepository.findByPostingIdAndMemberId(s.jobPostingId, customUserDetails.getId())?.id
+
+            val jobPostingResponse = JobPostingResponse.create(posting)
+            val resumeFileResponse = FileResponse.create(
+                s.resumeUrl,
+                objectStorageService.extractOriginalFilenameFromS3(s.resumeUrl)
+            )
+            val portfolioFileResponse = FileResponse.create(
+                s.portfolioUrl,
+                objectStorageService.extractOriginalFilenameFromS3(s.portfolioUrl)
+            )
+
+            DashboardResponse.create(
+                s.id,
+                memoId,
+                jobPostingResponse,
+                resumeFileResponse,
+                portfolioFileResponse
+            )
+        }
+        return PageImpl(dashboardList, PageRequest.of(page, size), dashboardList.size.toLong())
+    }
+
+    @Transactional(readOnly = true)
+    fun getById(id : Long) = findById(id) ?: throw DomainException(GlobalErrorCode.NOT_EXIST_SCRAP)
+
+    @Transactional(readOnly = true)
+    fun findById(id: Long) = scrapRepository.findByIdOrNull(id)
+
+    @Transactional
+    fun save(scrap: Scrap) = scrapRepository.save(scrap)
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 공고 스크랩 기능 구현
- 대시보드 조회 기능 구현

---

## ✏️ 관련 이슈
#32 

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 스크랩 생성·수정 API 및 대시보드 조회 API 추가 (POST/GET /scrap)
  - 대시보드에 공고 요약(제목, 만료일·D-day 등), 메모 연동(memoId) 및 연관 파일(이력서·포트폴리오) 정보 표시
  - 표준화된 페이지 응답(PageResponse) 및 파일/공고/대시보드용 응답 DTO 추가

- **개선**
  - 페이지·사이즈 기반 페이지네이션 지원(요청 1-base, 내부 0-base 처리)
  - 업로드된 파일에서 원본 파일명 추출 로직 개선(URL/쿼리·접두사 처리 및 URL 디코딩 시도)

- **버그 수정 / 오류 코드**
  - 존재하지 않는 스크랩/공고에 대해 명확한 BAD_REQUEST 오류 코드·메시지 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->