### PR TITLE
Feat(#37): 공고 분석 관련 파이프라인을 만들고 메모 저장시 공고가 함께 저장되도록 한다.

### DIFF
--- a/src/main/kotlin/com/zighang/core/clova/application/ClovaChatService.kt
+++ b/src/main/kotlin/com/zighang/core/clova/application/ClovaChatService.kt
@@ -13,7 +13,7 @@ class ClovaChatService(
 ) {
 
     fun getChat(request: ChatRequest) : ChatResponse? {
-        return clovaResponseMapper.toJobDescriptionDto(
+        return clovaResponseMapper.toJsonDto(
             clovaChatCompletionCaller.clovaChatCompletionApiCaller(
                 request.systemMessage, request.userMessage
             )

--- a/src/main/kotlin/com/zighang/core/clova/infrastructure/ClovaResponseMapper.kt
+++ b/src/main/kotlin/com/zighang/core/clova/infrastructure/ClovaResponseMapper.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component
 @Component
 class ClovaResponseMapper(objectMapper: ObjectMapper) :
     AbstractObjectMapper<ChatResponse?>(objectMapper) {
-    fun toJsonDto(json: String?): ChatResponse {
+    fun toJsonDto(json: String): ChatResponse {
         return parse<ChatResponse>(json, ChatResponse::class.java)
     }
 }

--- a/src/main/kotlin/com/zighang/core/clova/infrastructure/ClovaResponseMapper.kt
+++ b/src/main/kotlin/com/zighang/core/clova/infrastructure/ClovaResponseMapper.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component
 @Component
 class ClovaResponseMapper(objectMapper: ObjectMapper) :
     AbstractObjectMapper<ChatResponse?>(objectMapper) {
-    fun toJobDescriptionDto(json: String?): ChatResponse {
+    fun toJsonDto(json: String?): ChatResponse {
         return parse<ChatResponse>(json, ChatResponse::class.java)
     }
 }

--- a/src/main/kotlin/com/zighang/core/clova/util/JsonCleaner.kt
+++ b/src/main/kotlin/com/zighang/core/clova/util/JsonCleaner.kt
@@ -1,0 +1,16 @@
+package com.zighang.core.clova.util
+
+object JsonCleaner {
+    fun cleanJson(rawOutput: String): String {
+        // 1. ```json 또는 ``` 제거
+        var cleaned = rawOutput.replace("(?m)^```json|^```".toRegex(), "").trim { it <= ' ' }
+
+        // 2. 한 줄 주석 제거 (// ...)
+        cleaned = cleaned.replace("(?m)//.*?$".toRegex(), "")
+
+        // 3. 블록 주석 제거 (/* ... */)
+        cleaned = cleaned.replace("/\\*(?s).*?\\*/".toRegex(), "")
+
+        return cleaned
+    }
+}

--- a/src/main/kotlin/com/zighang/core/clova/util/JsonCleaner.kt
+++ b/src/main/kotlin/com/zighang/core/clova/util/JsonCleaner.kt
@@ -2,15 +2,41 @@ package com.zighang.core.clova.util
 
 object JsonCleaner {
     fun cleanJson(rawOutput: String): String {
-        // 1. ```json 또는 ``` 제거
-        var cleaned = rawOutput.replace("(?m)^```json|^```".toRegex(), "").trim { it <= ' ' }
+        // 1) 코드펜스 제거 (```json, ``` 등 - 대소문자/공백 허용)
+        val withoutFences = rawOutput
+            .replace("(?mi)^```\\s*\\w*\\s*$".toRegex(), "")
+            .trim()
 
-        // 2. 한 줄 주석 제거 (// ...)
-        cleaned = cleaned.replace("(?m)//.*?$".toRegex(), "")
+        // 2) 문자열 리터럴 바깥의 주석만 제거
+        val cleaned = stripJsonComments(withoutFences)
+        return cleaned.trim()
+    }
 
-        // 3. 블록 주석 제거 (/* ... */)
-        cleaned = cleaned.replace("/\\*(?s).*?\\*/".toRegex(), "")
-
-        return cleaned
+    private fun stripJsonComments(text: String): String {
+        val sb = StringBuilder(text.length)
+        var inString = false
+        var escape = false
+        var i = 0
+        while (i < text.length) {
+            val c = text[i]
+            if (inString) {
+                sb.append(c)
+                if (escape) {
+                    escape = false
+                } else {
+                    if (c == '\\') escape = true
+                    else if (c == '"') inString = false
+                }
+                i++; continue
+            }
+            if (c == '"') { inString = true; sb.append(c); i++; continue }
+            if (c == '/' && i + 1 < text.length) {
+                val n = text[i + 1]
+                if (n == '/') { i += 2; while (i < text.length && text[i] != '\n') i++; continue }
+                if (n == '*') { i += 2; while (i + 1 < text.length && !(text[i] == '*' && text[i + 1] == '/')) i++; i = minOf(i + 2, text.length); continue }
+            }
+            sb.append(c); i++
+        }
+        return sb.toString()
     }
 }

--- a/src/main/kotlin/com/zighang/core/config/rabbitmq/TestEventPublisher.kt
+++ b/src/main/kotlin/com/zighang/core/config/rabbitmq/TestEventPublisher.kt
@@ -3,6 +3,7 @@ package com.zighang.core.config.rabbitmq
 import com.zighang.core.clova.dto.ChatRequest
 import com.zighang.core.clova.dto.ClovaMessage
 import com.zighang.core.clova.dto.ClovaStudioRequest
+import com.zighang.core.config.rabbitmq.config.RabbitProperties
 import org.slf4j.LoggerFactory
 import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/com/zighang/core/config/rabbitmq/TestWorker.kt
+++ b/src/main/kotlin/com/zighang/core/config/rabbitmq/TestWorker.kt
@@ -1,6 +1,7 @@
 package com.zighang.core.config.rabbitmq
 
 import com.zighang.core.clova.dto.ClovaStudioRequest
+import com.zighang.core.config.rabbitmq.config.RabbitProperties
 import org.springframework.amqp.rabbit.annotation.RabbitListener
 import org.springframework.stereotype.Component
 

--- a/src/main/kotlin/com/zighang/core/config/rabbitmq/config/CustomErrorMessageRecover.kt
+++ b/src/main/kotlin/com/zighang/core/config/rabbitmq/config/CustomErrorMessageRecover.kt
@@ -1,9 +1,11 @@
 package com.zighang.core.config.rabbitmq.config
 
+import org.slf4j.LoggerFactory
 import org.springframework.amqp.core.Message
 import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.amqp.rabbit.retry.MessageRecoverer
 import org.springframework.stereotype.Component
+import java.util.*
 
 @Component
 class CustomErrorMessageRecover(
@@ -11,23 +13,45 @@ class CustomErrorMessageRecover(
     private val rabbitProperties: RabbitProperties
 ) : MessageRecoverer {
 
+    companion object {
+        private val log = LoggerFactory.getLogger(CustomErrorMessageRecover::class.java)
+    }
+
     // DLQ 핸들링시 DLQ에 입력 되는 데이터 형식 정리
     override fun recover(message: Message, cause: Throwable) {
-
         val props = message.messageProperties
+        val safeHeaders = props.headers.mapValues { (_, v) ->
+            when(v) {
+                is String, is Number, is Boolean, null -> v
+                else -> v.toString()
+            }
+        }
+
+        val bodyText = runCatching { String(message.body, Charsets.UTF_8) }
+            .getOrElse { Base64.getEncoder().encodeToString(message.body) }
 
         val errorMessage = mapOf(
             "error" to (cause.message ?: cause.javaClass.name),
             "errorType" to cause.javaClass.name,
+            "stackTrace" to cause.stackTraceToString(),
             "originalQueue" to props.consumerQueue,
             "originalRoutingKey" to props.receivedRoutingKey,
-            "headers" to props.headers,
+            "originalExchange" to props.receivedExchange,
+            "headers" to safeHeaders,
+            "body" to bodyText,
+            "timestamp" to java.time.Instant.now().toString(),
         )
-
-        rabbitTemplate.convertAndSend(
-            rabbitProperties.dlq.exchange,
-            rabbitProperties.dlq.routingKey,
-            errorMessage
-        )
+        try {
+            rabbitTemplate.convertAndSend(
+                rabbitProperties.dlq.exchange,
+                rabbitProperties.dlq.routingKey,
+                errorMessage
+            )
+        } catch(e: Exception) {
+            log.error(
+                "DLQ 전송 실패: exchange={}, routingKey={}, msgProps={}",
+                rabbitProperties.dlq.exchange, rabbitProperties.dlq.routingKey, props, e
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/zighang/core/config/rabbitmq/config/CustomErrorMessageRecover.kt
+++ b/src/main/kotlin/com/zighang/core/config/rabbitmq/config/CustomErrorMessageRecover.kt
@@ -1,4 +1,4 @@
-package com.zighang.core.config.rabbitmq
+package com.zighang.core.config.rabbitmq.config
 
 import org.springframework.amqp.core.Message
 import org.springframework.amqp.rabbit.core.RabbitTemplate

--- a/src/main/kotlin/com/zighang/core/config/rabbitmq/config/RabbitConfig.kt
+++ b/src/main/kotlin/com/zighang/core/config/rabbitmq/config/RabbitConfig.kt
@@ -1,11 +1,9 @@
-package com.zighang.core.config.rabbitmq
+package com.zighang.core.config.rabbitmq.config
 
-import org.springframework.amqp.core.*
 import org.springframework.amqp.rabbit.config.RetryInterceptorBuilder
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory
 import org.springframework.amqp.rabbit.connection.ConnectionFactory
 import org.springframework.amqp.rabbit.core.RabbitTemplate
-import org.springframework.amqp.rabbit.retry.RejectAndDontRequeueRecoverer
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter
 import org.springframework.amqp.support.converter.MessageConverter
 import org.springframework.context.annotation.Bean

--- a/src/main/kotlin/com/zighang/core/config/rabbitmq/config/RabbitConfig.kt
+++ b/src/main/kotlin/com/zighang/core/config/rabbitmq/config/RabbitConfig.kt
@@ -4,6 +4,7 @@ import org.springframework.amqp.rabbit.config.RetryInterceptorBuilder
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory
 import org.springframework.amqp.rabbit.connection.ConnectionFactory
 import org.springframework.amqp.rabbit.core.RabbitTemplate
+import org.springframework.amqp.rabbit.transaction.RabbitTransactionManager
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter
 import org.springframework.amqp.support.converter.MessageConverter
 import org.springframework.context.annotation.Bean
@@ -37,7 +38,7 @@ class RabbitConfig {
         factory.setMessageConverter(messageConverter)
 
         val interceptor = RetryInterceptorBuilder.stateless()
-            .maxAttempts(1)     // 단 1회 재시도
+            .maxAttempts(2)
             .recoverer(customErrorMessageRecover) // 실패시 DLQ로 이동
             .build()
 

--- a/src/main/kotlin/com/zighang/core/config/rabbitmq/config/RabbitInfraConfig.kt
+++ b/src/main/kotlin/com/zighang/core/config/rabbitmq/config/RabbitInfraConfig.kt
@@ -40,18 +40,18 @@ class RabbitInfraConfig(
 
     // 자격요건 / 우대사항 to Clova Queue
     @Bean
-    fun jobScrapedQueue(): Queue {
+    fun jobAnalysisQueue(): Queue {
         return Queue(
-            rabbitProperties.scraped.name, true, false, false, getDLQArgs()
+            rabbitProperties.analysis.name, true, false, false, getDLQArgs()
         )
     }
 
     @Bean
-    fun jobScrapedExchange(): DirectExchange = DirectExchange(rabbitProperties.scraped.exchange)
+    fun jobAnalysisExchange(): DirectExchange = DirectExchange(rabbitProperties.analysis.exchange)
 
     @Bean
-    fun jobScrapedBinding() : Binding =
-        BindingBuilder.bind(jobScrapedQueue()).to(jobScrapedExchange()).with(rabbitProperties.scraped.routingKey)
+    fun jobAnalysisBinding() : Binding =
+        BindingBuilder.bind(jobAnalysisQueue()).to(jobAnalysisExchange()).with(rabbitProperties.analysis.routingKey)
 
     // clova to update DB Queue
     @Bean

--- a/src/main/kotlin/com/zighang/core/config/rabbitmq/config/RabbitInfraConfig.kt
+++ b/src/main/kotlin/com/zighang/core/config/rabbitmq/config/RabbitInfraConfig.kt
@@ -1,4 +1,4 @@
-package com.zighang.core.config.rabbitmq
+package com.zighang.core.config.rabbitmq.config
 
 import org.springframework.amqp.core.Binding
 import org.springframework.amqp.core.BindingBuilder
@@ -37,6 +37,36 @@ class RabbitInfraConfig(
     @Bean
     fun testBinding(): Binding =
         BindingBuilder.bind(testQueue()).to(testExchange()).with(rabbitProperties.test.routingKey)
+
+    // 자격요건 / 우대사항 to Clova Queue
+    @Bean
+    fun jobScrapedQueue(): Queue {
+        return Queue(
+            rabbitProperties.scraped.name, true, false, false, getDLQArgs()
+        )
+    }
+
+    @Bean
+    fun jobScrapedExchange(): DirectExchange = DirectExchange(rabbitProperties.scraped.exchange)
+
+    @Bean
+    fun jobScrapedBinding() : Binding =
+        BindingBuilder.bind(jobScrapedQueue()).to(jobScrapedExchange()).with(rabbitProperties.scraped.routingKey)
+
+    // clova to update DB Queue
+    @Bean
+    fun jobEnrichedQueue() : Queue {
+        return Queue(
+            rabbitProperties.enriched.name, true, false, false, getDLQArgs()
+        )
+    }
+
+    @Bean
+    fun jobEnrichedExchange(): DirectExchange = DirectExchange(rabbitProperties.enriched.exchange)
+
+    @Bean
+    fun jobEnrichedBinding() :Binding =
+        BindingBuilder.bind(jobEnrichedQueue()).to(jobEnrichedExchange()).with(rabbitProperties.enriched.routingKey)
 
     // dlq 에러 핸들링을 위해 사용하는 Args
     private fun getDLQArgs() : Map<String, String> {

--- a/src/main/kotlin/com/zighang/core/config/rabbitmq/config/RabbitProperties.kt
+++ b/src/main/kotlin/com/zighang/core/config/rabbitmq/config/RabbitProperties.kt
@@ -12,10 +12,10 @@ data class RabbitProperties(
     val test: TestQueue = TestQueue(),
 
     @NestedConfigurationProperty
-    val scraped: ScrapedQueue = ScrapedQueue(),
+    val analysis: AnalysisQueue = AnalysisQueue(),
 
     @NestedConfigurationProperty
-    val enriched: enrichedQueue
+    val enriched: EnrichedQueue
 )
 
 data class DeadLetterQueue(
@@ -30,13 +30,13 @@ data class TestQueue(
     val routingKey: String = ""
 )
 
-data class ScrapedQueue(
+data class AnalysisQueue(
     val name: String = "",
     val exchange: String = "",
     val routingKey: String = ""
 )
 
-data class enrichedQueue(
+data class EnrichedQueue(
     val name: String = "",
     val exchange: String = "",
     val routingKey: String = ""

--- a/src/main/kotlin/com/zighang/core/config/rabbitmq/config/RabbitProperties.kt
+++ b/src/main/kotlin/com/zighang/core/config/rabbitmq/config/RabbitProperties.kt
@@ -1,4 +1,4 @@
-package com.zighang.core.config.rabbitmq
+package com.zighang.core.config.rabbitmq.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.NestedConfigurationProperty
@@ -10,6 +10,12 @@ data class RabbitProperties(
 
     @NestedConfigurationProperty
     val test: TestQueue = TestQueue(),
+
+    @NestedConfigurationProperty
+    val scraped: ScrapedQueue = ScrapedQueue(),
+
+    @NestedConfigurationProperty
+    val enriched: enrichedQueue
 )
 
 data class DeadLetterQueue(
@@ -19,6 +25,18 @@ data class DeadLetterQueue(
 )
 
 data class TestQueue(
+    val name: String = "",
+    val exchange: String = "",
+    val routingKey: String = ""
+)
+
+data class ScrapedQueue(
+    val name: String = "",
+    val exchange: String = "",
+    val routingKey: String = ""
+)
+
+data class enrichedQueue(
     val name: String = "",
     val exchange: String = "",
     val routingKey: String = ""

--- a/src/main/kotlin/com/zighang/jobposting/repository/JobPostingRepository.kt
+++ b/src/main/kotlin/com/zighang/jobposting/repository/JobPostingRepository.kt
@@ -1,9 +1,17 @@
 package com.zighang.jobposting.repository
 
 import com.zighang.jobposting.entity.JobPosting
+import jakarta.transaction.Transactional
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 interface JobPostingRepository : CrudRepository<JobPosting, Long> {
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE JobPosting j SET j.qualification = :qualification, j.preferentialTreatment = :preferentialTreatment WHERE j.id = :id")
+    fun updateJobPostingAnalysis(id: Long, qualification: String, preferentialTreatment: String)
 }

--- a/src/main/kotlin/com/zighang/jobposting/repository/JobPostingRepository.kt
+++ b/src/main/kotlin/com/zighang/jobposting/repository/JobPostingRepository.kt
@@ -5,13 +5,24 @@ import jakarta.transaction.Transactional
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
 interface JobPostingRepository : CrudRepository<JobPosting, Long> {
 
     @Transactional
-    @Modifying
-    @Query("UPDATE JobPosting j SET j.qualification = :qualification, j.preferentialTreatment = :preferentialTreatment WHERE j.id = :id")
-    fun updateJobPostingAnalysis(id: Long, qualification: String, preferentialTreatment: String)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+        """
+            UPDATE JobPosting j 
+            SET j.qualification = :qualification, j.preferentialTreatment = :preferentialTreatment 
+            WHERE j.id = :id
+        """
+    )
+    fun updateJobPostingAnalysis(
+        @Param("id") id: Long,
+        @Param("qualification") qualification: String,
+        @Param("preferentialTreatment") preferentialTreatment: String,
+    ) : Int
 }

--- a/src/main/kotlin/com/zighang/memo/service/MemoService.kt
+++ b/src/main/kotlin/com/zighang/memo/service/MemoService.kt
@@ -1,12 +1,17 @@
 package com.zighang.memo.service
 
 import com.zighang.core.infrastructure.CustomUserDetails
+import com.zighang.jobposting.entity.JobPosting
 import com.zighang.jobposting.repository.JobPostingRepository
 import com.zighang.memo.dto.request.MemoCreateRequest
 import com.zighang.memo.dto.response.MemoCreateResponse
 import com.zighang.memo.entity.Memo
 import com.zighang.memo.exception.MemoErrorCode
 import com.zighang.memo.repository.MemoRepository
+import com.zighang.scrap.dto.request.JobScrapedEvent
+import com.zighang.scrap.entity.Scrap
+import com.zighang.scrap.infrastructure.JobAnalysisEventProducer
+import com.zighang.scrap.repository.ScrapRepository
 import jakarta.transaction.Transactional
 import lombok.extern.slf4j.Slf4j
 import org.springframework.data.repository.findByIdOrNull
@@ -17,16 +22,37 @@ import org.springframework.stereotype.Service
 class MemoService(
     private val memoRepository: MemoRepository,
     private val jobPostingRepository: JobPostingRepository,
+    private val scrapRepository: ScrapRepository,
+    private val jobAnalysisEventProducer: JobAnalysisEventProducer
 ) {
     
-    // 추후 스크랩 추가시 스크랩 자동으로 되는 로직 추가해야 함
     @Transactional
-    fun saveMemo(customUserDetails: CustomUserDetails, request: MemoCreateRequest) : MemoCreateResponse{
+    fun saveMemo(
+        customUserDetails: CustomUserDetails,
+        request: MemoCreateRequest
+    ) : MemoCreateResponse{
 
-        jobPostingRepository.findByIdOrNull(request.postingId)
+        val jobPosting = jobPostingRepository.findByIdOrNull(request.postingId)
             ?: throw MemoErrorCode.NOT_EXIST_POSTING.toException();
 
         val memberId = getMemberId(customUserDetails)
+
+        // 메모 저장시 스크랩이 안되어 있다면 같이 저장
+        getJobPostingByPostingIdAndMemberId(request.postingId, memberId) ?: run {
+            if(isAnalysisNeed(jobPosting)) {
+                jobAnalysisEventProducer.publishAnalysis(
+                    JobScrapedEvent(request.postingId, jobPosting.ocrData)
+                )
+            }
+
+            val newScrap = Scrap.create(
+                jobPostingId = request.postingId,
+                memberId = memberId,
+                resumeUrl = null,
+                portfolioUrl = null
+            )
+            scrapRepository.save(newScrap)
+        }
 
         memoRepository.findByPostingIdAndMemberId(request.postingId, memberId)?.let{
             it.update(request.content)
@@ -48,5 +74,13 @@ class MemoService(
 
     private fun getMemberId(customUserDetails: CustomUserDetails): Long {
         return customUserDetails.getId()
+    }
+
+    private fun getJobPostingByPostingIdAndMemberId(postingId: Long, memberId: Long): Scrap? {
+        return scrapRepository.findByJobPostingIdAndMemberId(postingId, memberId)
+    }
+
+    private fun isAnalysisNeed(jobPosting: JobPosting) : Boolean {
+        return jobPosting.qualification.isNullOrBlank() || jobPosting.preferentialTreatment.isNullOrBlank()
     }
 }

--- a/src/main/kotlin/com/zighang/memo/service/MemoService.kt
+++ b/src/main/kotlin/com/zighang/memo/service/MemoService.kt
@@ -1,17 +1,14 @@
 package com.zighang.memo.service
 
 import com.zighang.core.infrastructure.CustomUserDetails
-import com.zighang.jobposting.entity.JobPosting
 import com.zighang.jobposting.repository.JobPostingRepository
 import com.zighang.memo.dto.request.MemoCreateRequest
 import com.zighang.memo.dto.response.MemoCreateResponse
 import com.zighang.memo.entity.Memo
 import com.zighang.memo.exception.MemoErrorCode
 import com.zighang.memo.repository.MemoRepository
-import com.zighang.scrap.dto.request.JobScrapedEvent
 import com.zighang.scrap.dto.request.UpsertScrapRequest
 import com.zighang.scrap.entity.Scrap
-import com.zighang.scrap.infrastructure.JobAnalysisEventProducer
 import com.zighang.scrap.repository.ScrapRepository
 import com.zighang.scrap.service.ScrapService
 import jakarta.transaction.Transactional

--- a/src/main/kotlin/com/zighang/scrap/dto/request/JobEnrichedEvent.kt
+++ b/src/main/kotlin/com/zighang/scrap/dto/request/JobEnrichedEvent.kt
@@ -1,0 +1,10 @@
+package com.zighang.scrap.dto.request
+
+import com.zighang.scrap.dto.response.JobPostingAnalysisDto
+
+data class JobEnrichedEvent(
+
+    val id : Long = 0L,
+
+    val jobPostingAnalysisDto: JobPostingAnalysisDto,
+)

--- a/src/main/kotlin/com/zighang/scrap/dto/request/JobEnrichedEvent.kt
+++ b/src/main/kotlin/com/zighang/scrap/dto/request/JobEnrichedEvent.kt
@@ -4,7 +4,7 @@ import com.zighang.scrap.dto.response.JobPostingAnalysisDto
 
 data class JobEnrichedEvent(
 
-    val id : Long = 0L,
+    val id : Long,
 
     val jobPostingAnalysisDto: JobPostingAnalysisDto,
 )

--- a/src/main/kotlin/com/zighang/scrap/dto/request/JobScrapedEvent.kt
+++ b/src/main/kotlin/com/zighang/scrap/dto/request/JobScrapedEvent.kt
@@ -1,7 +1,12 @@
 package com.zighang.scrap.dto.request
 
-data class JobScrapedEvent (
-    val id: Long = 0,
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 
-    val ocrData: String = "",
+data class JobScrapedEvent (
+    @field:NotNull
+    val id: Long,
+
+    @field:NotBlank
+    val ocrData: String,
 )

--- a/src/main/kotlin/com/zighang/scrap/dto/request/JobScrapedEvent.kt
+++ b/src/main/kotlin/com/zighang/scrap/dto/request/JobScrapedEvent.kt
@@ -1,0 +1,7 @@
+package com.zighang.scrap.dto.request
+
+data class JobScrapedEvent (
+    val id: Long = 0,
+
+    val ocrData: String = "",
+)

--- a/src/main/kotlin/com/zighang/scrap/dto/request/ScrapDeleteRequest.kt
+++ b/src/main/kotlin/com/zighang/scrap/dto/request/ScrapDeleteRequest.kt
@@ -1,0 +1,10 @@
+package com.zighang.scrap.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotEmpty
+
+data class ScrapDeleteRequest(
+    @Schema(description = "삭제할 스크랩 식별자 리스트", example = "[1, 2, 3]")
+    @field:NotEmpty(message = "삭제할 스크랩 ID는 비어있을 수 없습니다.")
+    val idList: List<Long>
+)

--- a/src/main/kotlin/com/zighang/scrap/dto/request/ScrapDeleteRequest.kt
+++ b/src/main/kotlin/com/zighang/scrap/dto/request/ScrapDeleteRequest.kt
@@ -2,9 +2,10 @@ package com.zighang.scrap.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.Positive
 
 data class ScrapDeleteRequest(
     @Schema(description = "삭제할 스크랩 식별자 리스트", example = "[1, 2, 3]")
     @field:NotEmpty(message = "삭제할 스크랩 ID는 비어있을 수 없습니다.")
-    val idList: List<Long>
+    val idList: List<@Positive Long>
 )

--- a/src/main/kotlin/com/zighang/scrap/dto/response/JobPostingAnalysisDto.kt
+++ b/src/main/kotlin/com/zighang/scrap/dto/response/JobPostingAnalysisDto.kt
@@ -2,7 +2,7 @@ package com.zighang.scrap.dto.response
 
 data class JobPostingAnalysisDto(
 
-    val qualification: String,
+    val qualification: String = "",
 
-    val preferentialTreatment: String,
+    val preferentialTreatment: String = "",
 )

--- a/src/main/kotlin/com/zighang/scrap/dto/response/JobPostingAnalysisDto.kt
+++ b/src/main/kotlin/com/zighang/scrap/dto/response/JobPostingAnalysisDto.kt
@@ -1,0 +1,8 @@
+package com.zighang.scrap.dto.response
+
+data class JobPostingAnalysisDto(
+
+    val qualification: String,
+
+    val preferentialTreatment: String,
+)

--- a/src/main/kotlin/com/zighang/scrap/infrastructure/JobAnalysisCaller.kt
+++ b/src/main/kotlin/com/zighang/scrap/infrastructure/JobAnalysisCaller.kt
@@ -13,6 +13,11 @@ class JobAnalysisCaller(
 ) {
 
     fun call(ocrData : String) : ChatResponse {
+        val systemMessage = SystemMessageFactory.jobAnalysisSystemMessageFactory()
+
+        require(systemMessage.isNotBlank()) { "jobAnalysis system message must not be blank" }
+        require(ocrData.isNotBlank()) { "ocrData must not be blank" }
+
         val result = clovaChatCompletionCaller.clovaChatCompletionApiCaller(
             SystemMessageFactory.jobAnalysisSystemMessageFactory(),
             ocrData

--- a/src/main/kotlin/com/zighang/scrap/infrastructure/JobAnalysisCaller.kt
+++ b/src/main/kotlin/com/zighang/scrap/infrastructure/JobAnalysisCaller.kt
@@ -1,0 +1,23 @@
+package com.zighang.scrap.infrastructure
+
+import com.zighang.core.clova.dto.ChatResponse
+import com.zighang.core.clova.infrastructure.ClovaChatCompletionCaller
+import com.zighang.core.clova.infrastructure.ClovaResponseMapper
+import com.zighang.scrap.util.SystemMessageFactory
+import org.springframework.stereotype.Component
+
+@Component
+class JobAnalysisCaller(
+    private val clovaChatCompletionCaller: ClovaChatCompletionCaller,
+    private val clovaResponseMapper: ClovaResponseMapper
+) {
+
+    fun call(ocrData : String) : ChatResponse {
+        val result = clovaChatCompletionCaller.clovaChatCompletionApiCaller(
+            SystemMessageFactory.jobAnalysisSystemMessageFactory(),
+            ocrData
+        )
+
+        return clovaResponseMapper.toJsonDto(result)
+    }
+}

--- a/src/main/kotlin/com/zighang/scrap/infrastructure/JobAnalysisEventProducer.kt
+++ b/src/main/kotlin/com/zighang/scrap/infrastructure/JobAnalysisEventProducer.kt
@@ -1,0 +1,29 @@
+package com.zighang.scrap.infrastructure
+
+import com.zighang.core.config.rabbitmq.config.RabbitProperties
+import com.zighang.scrap.dto.request.JobEnrichedEvent
+import com.zighang.scrap.dto.request.JobScrapedEvent
+import org.springframework.amqp.rabbit.core.RabbitTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class JobAnalysisEventProducer(
+    private val rabbitTemplate: RabbitTemplate,
+    private val rabbitProperties: RabbitProperties
+) {
+    fun publishAnalysis(event: JobScrapedEvent) {
+        rabbitTemplate.convertAndSend(
+            rabbitProperties.scraped.exchange,
+            rabbitProperties.scraped.routingKey,
+            event
+        )
+    }
+
+    fun publishEnriched(event: JobEnrichedEvent) {
+        rabbitTemplate.convertAndSend(
+            rabbitProperties.enriched.exchange,
+            rabbitProperties.enriched.routingKey,
+            event
+        )
+    }
+}

--- a/src/main/kotlin/com/zighang/scrap/infrastructure/JobAnalysisEventProducer.kt
+++ b/src/main/kotlin/com/zighang/scrap/infrastructure/JobAnalysisEventProducer.kt
@@ -13,8 +13,8 @@ class JobAnalysisEventProducer(
 ) {
     fun publishAnalysis(event: JobScrapedEvent) {
         rabbitTemplate.convertAndSend(
-            rabbitProperties.scraped.exchange,
-            rabbitProperties.scraped.routingKey,
+            rabbitProperties.analysis.exchange,
+            rabbitProperties.analysis.routingKey,
             event
         )
     }

--- a/src/main/kotlin/com/zighang/scrap/infrastructure/mapper/JobAnalysisDtoMapper.kt
+++ b/src/main/kotlin/com/zighang/scrap/infrastructure/mapper/JobAnalysisDtoMapper.kt
@@ -1,0 +1,17 @@
+package com.zighang.scrap.infrastructure.mapper
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.zighang.core.clova.dto.ChatResponse
+import com.zighang.core.infrastructure.mapper.AbstractObjectMapper
+import com.zighang.scrap.dto.response.JobPostingAnalysisDto
+import org.springframework.stereotype.Component
+
+@Component
+class JobAnalysisDtoMapper(
+    objectMapper: ObjectMapper
+)
+: AbstractObjectMapper<JobPostingAnalysisDto?>(objectMapper) {
+    fun toJsonDto(json: String?): JobPostingAnalysisDto {
+        return parse<JobPostingAnalysisDto>(json, JobPostingAnalysisDto::class.java)
+    }
+}

--- a/src/main/kotlin/com/zighang/scrap/infrastructure/publisher/AIRequestPublisher.kt
+++ b/src/main/kotlin/com/zighang/scrap/infrastructure/publisher/AIRequestPublisher.kt
@@ -1,4 +1,0 @@
-package com.zighang.scrap.infrastructure.publisher
-
-class AIRequestPublisher {
-}

--- a/src/main/kotlin/com/zighang/scrap/infrastructure/publisher/AIRequestPublisher.kt
+++ b/src/main/kotlin/com/zighang/scrap/infrastructure/publisher/AIRequestPublisher.kt
@@ -1,0 +1,4 @@
+package com.zighang.scrap.infrastructure.publisher
+
+class AIRequestPublisher {
+}

--- a/src/main/kotlin/com/zighang/scrap/infrastructure/worker/AIReqeustWorker.kt
+++ b/src/main/kotlin/com/zighang/scrap/infrastructure/worker/AIReqeustWorker.kt
@@ -1,8 +1,43 @@
 package com.zighang.scrap.infrastructure.worker
 
-import org.springframework.amqp.rabbit.core.RabbitTemplate
+import com.zighang.core.config.rabbitmq.config.RabbitProperties
+import com.zighang.scrap.dto.request.JobEnrichedEvent
+import com.zighang.scrap.dto.request.JobScrapedEvent
+import com.zighang.scrap.dto.response.JobPostingAnalysisDto
+import com.zighang.scrap.infrastructure.JobAnalysisEventProducer
+import lombok.extern.slf4j.Slf4j
+import org.slf4j.LoggerFactory
+import org.springframework.amqp.rabbit.annotation.RabbitListener
+import org.springframework.stereotype.Component
 
+@Component
+@Slf4j
 class AIReqeustWorker(
-
+    private val jobAnalysisEventProducer: JobAnalysisEventProducer
 ) {
+
+    private val log = LoggerFactory.getLogger(AIReqeustWorker::class.java)
+
+    @RabbitListener(queues= ["\${mq.scraped.name}"])
+    fun jobPostingToClova(event : JobScrapedEvent) {
+        log.info("analysis consumer : $event")
+
+        // clova 자격 우대사항 요건
+
+        jobAnalysisEventProducer.publishEnriched(
+            JobEnrichedEvent(
+                event.id,
+                JobPostingAnalysisDto(
+                    "자격요건", "우대사항"
+                )
+            )
+        )
+    }
+
+    @RabbitListener(queues= ["\${mq.enriched.name}"])
+    fun jobEnriched(event : JobEnrichedEvent) {
+        log.info("enrich consumer : $event")
+
+        // DB 업데이트 로직
+    }
 }

--- a/src/main/kotlin/com/zighang/scrap/infrastructure/worker/AIReqeustWorker.kt
+++ b/src/main/kotlin/com/zighang/scrap/infrastructure/worker/AIReqeustWorker.kt
@@ -1,10 +1,13 @@
 package com.zighang.scrap.infrastructure.worker
 
+import com.zighang.core.clova.util.JsonCleaner
 import com.zighang.core.config.rabbitmq.config.RabbitProperties
 import com.zighang.scrap.dto.request.JobEnrichedEvent
 import com.zighang.scrap.dto.request.JobScrapedEvent
 import com.zighang.scrap.dto.response.JobPostingAnalysisDto
+import com.zighang.scrap.infrastructure.JobAnalysisCaller
 import com.zighang.scrap.infrastructure.JobAnalysisEventProducer
+import com.zighang.scrap.infrastructure.mapper.JobAnalysisDtoMapper
 import lombok.extern.slf4j.Slf4j
 import org.slf4j.LoggerFactory
 import org.springframework.amqp.rabbit.annotation.RabbitListener
@@ -13,25 +16,31 @@ import org.springframework.stereotype.Component
 @Component
 @Slf4j
 class AIReqeustWorker(
-    private val jobAnalysisEventProducer: JobAnalysisEventProducer
+    private val jobAnalysisEventProducer: JobAnalysisEventProducer,
+    private val jobAnalysisCaller: JobAnalysisCaller,
+    private val jobAnalysisDtoMapper: JobAnalysisDtoMapper
 ) {
 
     private val log = LoggerFactory.getLogger(AIReqeustWorker::class.java)
 
     @RabbitListener(queues= ["\${mq.analysis.name}"])
     fun jobPostingToClova(event : JobScrapedEvent) {
-        log.info("analysis consumer : $event")
-
         // clova 자격 우대사항 요건
+        val result = jobAnalysisCaller.call(event.ocrData).result.message.content
+
+        val jobPostingAnalysisDto = jobAnalysisDtoMapper.toJsonDto(JsonCleaner.cleanJson(result))
+
+        log.info(jobPostingAnalysisDto.toString())
 
         jobAnalysisEventProducer.publishEnriched(
             JobEnrichedEvent(
                 event.id,
                 JobPostingAnalysisDto(
-                    "자격요건", "우대사항"
+                    jobPostingAnalysisDto.qualification, jobPostingAnalysisDto.preferentialTreatment
                 )
             )
         )
+        log.info("publish : analysis -> enrich")
     }
 
     @RabbitListener(queues= ["\${mq.enriched.name}"])

--- a/src/main/kotlin/com/zighang/scrap/infrastructure/worker/AIReqeustWorker.kt
+++ b/src/main/kotlin/com/zighang/scrap/infrastructure/worker/AIReqeustWorker.kt
@@ -18,7 +18,7 @@ class AIReqeustWorker(
 
     private val log = LoggerFactory.getLogger(AIReqeustWorker::class.java)
 
-    @RabbitListener(queues= ["\${mq.scraped.name}"])
+    @RabbitListener(queues= ["\${mq.analysis.name}"])
     fun jobPostingToClova(event : JobScrapedEvent) {
         log.info("analysis consumer : $event")
 

--- a/src/main/kotlin/com/zighang/scrap/infrastructure/worker/AIReqeustWorker.kt
+++ b/src/main/kotlin/com/zighang/scrap/infrastructure/worker/AIReqeustWorker.kt
@@ -1,0 +1,8 @@
+package com.zighang.scrap.infrastructure.worker
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate
+
+class AIReqeustWorker(
+
+) {
+}

--- a/src/main/kotlin/com/zighang/scrap/infrastructure/worker/AIRequestWorker.kt
+++ b/src/main/kotlin/com/zighang/scrap/infrastructure/worker/AIRequestWorker.kt
@@ -1,36 +1,29 @@
 package com.zighang.scrap.infrastructure.worker
 
 import com.zighang.core.clova.util.JsonCleaner
-import com.zighang.core.config.rabbitmq.config.RabbitProperties
+import com.zighang.jobposting.repository.JobPostingRepository
 import com.zighang.scrap.dto.request.JobEnrichedEvent
 import com.zighang.scrap.dto.request.JobScrapedEvent
 import com.zighang.scrap.dto.response.JobPostingAnalysisDto
 import com.zighang.scrap.infrastructure.JobAnalysisCaller
 import com.zighang.scrap.infrastructure.JobAnalysisEventProducer
 import com.zighang.scrap.infrastructure.mapper.JobAnalysisDtoMapper
-import lombok.extern.slf4j.Slf4j
-import org.slf4j.LoggerFactory
 import org.springframework.amqp.rabbit.annotation.RabbitListener
 import org.springframework.stereotype.Component
 
 @Component
-@Slf4j
-class AIReqeustWorker(
+class AIRequestWorker(
     private val jobAnalysisEventProducer: JobAnalysisEventProducer,
     private val jobAnalysisCaller: JobAnalysisCaller,
-    private val jobAnalysisDtoMapper: JobAnalysisDtoMapper
+    private val jobAnalysisDtoMapper: JobAnalysisDtoMapper,
+    private val jobPostingRepository: JobPostingRepository
 ) {
-
-    private val log = LoggerFactory.getLogger(AIReqeustWorker::class.java)
-
     @RabbitListener(queues= ["\${mq.analysis.name}"])
     fun jobPostingToClova(event : JobScrapedEvent) {
-        // clova 자격 우대사항 요건
+        // clova 자격요건/우대사항 분석
         val result = jobAnalysisCaller.call(event.ocrData).result.message.content
 
         val jobPostingAnalysisDto = jobAnalysisDtoMapper.toJsonDto(JsonCleaner.cleanJson(result))
-
-        log.info(jobPostingAnalysisDto.toString())
 
         jobAnalysisEventProducer.publishEnriched(
             JobEnrichedEvent(
@@ -40,13 +33,14 @@ class AIReqeustWorker(
                 )
             )
         )
-        log.info("publish : analysis -> enrich")
     }
 
     @RabbitListener(queues= ["\${mq.enriched.name}"])
     fun jobEnriched(event : JobEnrichedEvent) {
-        log.info("enrich consumer : $event")
-
-        // DB 업데이트 로직
+        jobPostingRepository.updateJobPostingAnalysis(
+            event.id,
+            event.jobPostingAnalysisDto.qualification,
+            event.jobPostingAnalysisDto.preferentialTreatment
+        )
     }
 }

--- a/src/main/kotlin/com/zighang/scrap/infrastructure/worker/AIRequestWorker.kt
+++ b/src/main/kotlin/com/zighang/scrap/infrastructure/worker/AIRequestWorker.kt
@@ -1,6 +1,7 @@
 package com.zighang.scrap.infrastructure.worker
 
 import com.zighang.core.clova.util.JsonCleaner
+import com.zighang.core.exception.GlobalErrorCode
 import com.zighang.jobposting.repository.JobPostingRepository
 import com.zighang.scrap.dto.request.JobEnrichedEvent
 import com.zighang.scrap.dto.request.JobScrapedEvent
@@ -20,27 +21,39 @@ class AIRequestWorker(
 ) {
     @RabbitListener(queues= ["\${mq.analysis.name}"])
     fun jobPostingToClova(event : JobScrapedEvent) {
-        // clova 자격요건/우대사항 분석
-        val result = jobAnalysisCaller.call(event.ocrData).result.message.content
+        try {
+            // clova 자격요건/우대사항 분석
+            val result = jobAnalysisCaller.call(event.ocrData).result.message.content
 
-        val jobPostingAnalysisDto = jobAnalysisDtoMapper.toJsonDto(JsonCleaner.cleanJson(result))
+            val jobPostingAnalysisDto = jobAnalysisDtoMapper.toJsonDto(JsonCleaner.cleanJson(result))
 
-        jobAnalysisEventProducer.publishEnriched(
-            JobEnrichedEvent(
-                event.id,
-                JobPostingAnalysisDto(
-                    jobPostingAnalysisDto.qualification, jobPostingAnalysisDto.preferentialTreatment
+            jobAnalysisEventProducer.publishEnriched(
+                JobEnrichedEvent(
+                    event.id,
+                    JobPostingAnalysisDto(
+                        jobPostingAnalysisDto.qualification, jobPostingAnalysisDto.preferentialTreatment
+                    )
                 )
             )
-        )
+        } catch (e: Exception) {
+            throw GlobalErrorCode.CLOVA_API_CALL_FAILED.toException()
+        }
     }
 
     @RabbitListener(queues= ["\${mq.enriched.name}"])
     fun jobEnriched(event : JobEnrichedEvent) {
-        jobPostingRepository.updateJobPostingAnalysis(
-            event.id,
-            event.jobPostingAnalysisDto.qualification,
-            event.jobPostingAnalysisDto.preferentialTreatment
-        )
+        try{
+            val updatedRows = jobPostingRepository.updateJobPostingAnalysis(
+                event.id,
+                event.jobPostingAnalysisDto.qualification,
+                event.jobPostingAnalysisDto.preferentialTreatment
+            )
+
+            if(updatedRows == 0) {
+                throw IllegalArgumentException("posting id : ${event.id}의 자격요건/우대사항 업데이트를 실패했습니다.")
+            }
+        }catch (e:Exception){
+            throw GlobalErrorCode.INTERNAL_SERVER_ERROR.toException()
+        }
     }
 }

--- a/src/main/kotlin/com/zighang/scrap/presentation/ScrapController.kt
+++ b/src/main/kotlin/com/zighang/scrap/presentation/ScrapController.kt
@@ -54,7 +54,7 @@ class ScrapController(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails,
         @RequestBody @Valid request: ScrapDeleteRequest
     ) {
-        scrapService.scrapDeleteService(request.idList)
+        scrapService.scrapDeleteService(customUserDetails, request.idList)
     }
 
 }

--- a/src/main/kotlin/com/zighang/scrap/presentation/ScrapController.kt
+++ b/src/main/kotlin/com/zighang/scrap/presentation/ScrapController.kt
@@ -3,11 +3,14 @@ package com.zighang.scrap.presentation
 import com.zighang.core.infrastructure.CustomUserDetails
 import com.zighang.core.presentation.PageResponse
 import com.zighang.core.presentation.RestResponse
+import com.zighang.scrap.dto.request.ScrapDeleteRequest
 import com.zighang.scrap.dto.request.UpsertScrapRequest
 import com.zighang.scrap.dto.response.DashboardResponse
 import com.zighang.scrap.presentation.swagger.ScrapSwagger
 import com.zighang.scrap.service.ScrapService
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
@@ -45,5 +48,13 @@ class ScrapController(
         )
     }
 
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    override fun deleteScraps(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @RequestBody @Valid request: ScrapDeleteRequest
+    ) {
+        scrapService.scrapDeleteService(request.idList)
+    }
 
 }

--- a/src/main/kotlin/com/zighang/scrap/presentation/swagger/ScrapSwagger.kt
+++ b/src/main/kotlin/com/zighang/scrap/presentation/swagger/ScrapSwagger.kt
@@ -3,9 +3,11 @@ package com.zighang.scrap.presentation.swagger
 import com.zighang.core.infrastructure.CustomUserDetails
 import com.zighang.core.presentation.PageResponse
 import com.zighang.core.presentation.RestResponse
+import com.zighang.scrap.dto.request.ScrapDeleteRequest
 import com.zighang.scrap.dto.request.UpsertScrapRequest
 import com.zighang.scrap.dto.response.DashboardResponse
 import io.swagger.v3.oas.annotations.Operation
+import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
@@ -33,4 +35,10 @@ interface ScrapSwagger {
         @RequestParam(name = "page", defaultValue = "1") page : Int,
         @RequestParam(name = "size", defaultValue = "10") size : Int,
     ) : ResponseEntity<PageResponse<DashboardResponse>>
+
+    @Operation(summary = "스크랩 삭제", description = "스크랩 식별자를 통해 스크랩을 삭제합니다.")
+    fun deleteScraps(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @RequestBody @Valid request: ScrapDeleteRequest
+    )
 }

--- a/src/main/kotlin/com/zighang/scrap/repository/ScrapRepository.kt
+++ b/src/main/kotlin/com/zighang/scrap/repository/ScrapRepository.kt
@@ -8,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface ScrapRepository : JpaRepository<Scrap, Long> {
     fun findAllByMemberId(memberId : Long, pageable: Pageable) : Page<Scrap>
 
-    fun findByJobPostingIdAndMemberId(jobPostingId : Long?, memberId : Long) : Scrap?
+    fun findByJobPostingIdAndMemberId(jobPostingId : Long, memberId : Long) : Scrap?
 }

--- a/src/main/kotlin/com/zighang/scrap/repository/ScrapRepository.kt
+++ b/src/main/kotlin/com/zighang/scrap/repository/ScrapRepository.kt
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface ScrapRepository : JpaRepository<Scrap, Long> {
     fun findAllByMemberId(memberId : Long, pageable: Pageable) : Page<Scrap>
+
+    fun findByJobPostingIdAndMemberId(jobPostingId : Long?, memberId : Long) : Scrap?
 }

--- a/src/main/kotlin/com/zighang/scrap/service/ScrapService.kt
+++ b/src/main/kotlin/com/zighang/scrap/service/ScrapService.kt
@@ -110,6 +110,11 @@ class ScrapService(
         return PageImpl(dashboards, pageable, scrapPage.totalElements)
     }
 
+    @Transactional
+    fun scrapDeleteService(idList: List<Long>){
+        deleteByIdList(idList)
+    }
+
     @Transactional(readOnly = true)
     fun getById(id : Long) = findById(id) ?: throw DomainException(GlobalErrorCode.NOT_EXIST_SCRAP)
 
@@ -118,4 +123,7 @@ class ScrapService(
 
     @Transactional
     fun save(scrap: Scrap) = scrapRepository.save(scrap)
+
+    @Transactional
+    fun deleteByIdList(idList: List<Long>) = scrapRepository.deleteAllById(idList)
 }

--- a/src/main/kotlin/com/zighang/scrap/util/SystemMessageFactory.kt
+++ b/src/main/kotlin/com/zighang/scrap/util/SystemMessageFactory.kt
@@ -1,0 +1,34 @@
+package com.zighang.scrap.util
+
+class SystemMessageFactory {
+
+
+    companion object{
+        private val jobAnalysisSystemMessage: String = """
+            유저가 보내주는 공고 요약을 보고 자격요건과 우대사항을 분석해주세요.
+            **반드시 아래 규칙을 지켜주세요:**
+    
+            1. 출력은 **JSON 형식**으로 하고, **다른 키를 만들지 마세요.**
+            2. JSON 키는 반드시 영어로:
+               - 자격요건 → "qualification"
+               - 우대사항 → "preferentialTreatment"
+            3. 각 항목은 반드시 **줄글 형식**, '•'로 시작, **구어체 존댓말(-합니다, -해요)** 사용
+            4. 공고에 나온 **모든 내용**(부가 조건, 수습기간, 급여, 보험 등)을 기존 키 안에 포함
+            5. 절대 배열(`[]`) 형태로 만들지 마세요. 모든 내용은 하나의 문자열 안에 줄바꿈 `\n`으로 구분
+            6. 공고 내용이 분석 불가 시, `"qualification"`과 `"preferentialTreatment"` 각각에
+               `"해당 공고에 대한 자격요건/우대사항을 분석할 수 없습니다."`라고 작성
+    
+            아래 형식에 맞춰 오직 JSON만 출력해주세요.
+            설명, 마크다운(````json 포함), 주석 없이 JSON 본문만 출력하고
+            모든 key는 아래 형식과 정확히 일치해야 하며, 대소문자나 철자를 절대 변경하지 마세요.
+            {
+              "qualification": "• B2B 서비스 기획/PM/PMO 관련 업무 경험이 있으시면 좋습니다.\n• Excel/PowerPoint 등 문서 활용이 능숙하시면 업무에 도움이 됩니다.\n• 수습기간 및 급여 조건, 4대 보험, 퇴직금 등 기타 조건도 이 항목 안에 포함해 주세요.",
+              "preferentialTreatment": "• Jira/Confluence 등 협업 도구를 사용해 보신 경험이 있으면 우대합니다.\n• 관련 경험이나 자격증 등이 있으시면 우대합니다."
+            }
+        """.trimIndent()
+
+        fun jobAnalysisSystemMessageFactory(): String {
+            return jobAnalysisSystemMessage
+        }
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 공고 분석 파이프라인 완료
- 메모 저장시 분석 돌아가게함 (공고도 함께 저장)

---

## ✏️ 관련 이슈
#37 

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 자동 채용공고 분석: 스크랩 생성/업데이트 시 자격요건·우대사항을 백그라운드로 추출해 공고에 반영합니다.
  - 스크랩 대량 삭제 API 추가: ID 목록으로 여러 스크랩을 한 번에 삭제(입력 검증 포함)합니다.
  - 메모 저장 시 자동 스크랩 생성: 해당 공고가 없으면 자동으로 스크랩을 생성합니다.
- 작업
  - 메시지 큐(분석·보강 처리) 및 실패 메시지 전송(DLQ) 구성 강화로 안정성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->