### PR TITLE
Feat(#40): 스크랩 관련 API의 기능을 세분화한다.

### DIFF
--- a/src/main/kotlin/com/zighang/core/exception/GlobalErrorCode.kt
+++ b/src/main/kotlin/com/zighang/core/exception/GlobalErrorCode.kt
@@ -15,6 +15,8 @@ enum class GlobalErrorCode(
     NOT_EXIST_ONBOARDING(HttpStatus.BAD_REQUEST, "온보딩 데이터가 존재하지 않습니다"),
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
     FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다."),
+    IS_NOT_YOUR_FILE(HttpStatus.BAD_REQUEST, "본인의 파일만 삭제할 수 있습니다."),
+    CANNOT_EXTRACT_FILENAME(HttpStatus.INTERNAL_SERVER_ERROR, "원본 파일 이름을 추출하는데 실패했습니다."),
     NOT_EXIST_SCRAP(HttpStatus.BAD_REQUEST, "해당 스크랩 공고가 존재하지 않습니다."),
     NOT_EXIST_JOB_POSTING(HttpStatus.BAD_REQUEST, "해당 공고를 찾을 수 없습니다."),
     CLOVA_API_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "클로바 API 연결에 실패했습니다."),

--- a/src/main/kotlin/com/zighang/memo/service/MemoService.kt
+++ b/src/main/kotlin/com/zighang/memo/service/MemoService.kt
@@ -43,8 +43,6 @@ class MemoService(
                 UpsertScrapRequest(
                     jobPostingId = request.postingId,
                     scrapId = null,
-                    resumeUrl = null,
-                    portfolioUrl = null
                 )
             )
         }

--- a/src/main/kotlin/com/zighang/scrap/dto/request/UpsertScrapRequest.kt
+++ b/src/main/kotlin/com/zighang/scrap/dto/request/UpsertScrapRequest.kt
@@ -7,8 +7,4 @@ data class UpsertScrapRequest(
     val scrapId : Long?,
     @Schema(description = "공고 식별자", example = "1")
     val jobPostingId : Long,
-    @Schema(description = "이력서 url", example = "http://url")
-    val resumeUrl : String?,
-    @Schema(description = "포트폴리오 url",  example = "http://url")
-    val portfolioUrl : String?
 )

--- a/src/main/kotlin/com/zighang/scrap/dto/response/FileDeleteResponse.kt
+++ b/src/main/kotlin/com/zighang/scrap/dto/response/FileDeleteResponse.kt
@@ -1,0 +1,25 @@
+package com.zighang.scrap.dto.response
+
+data class FileDeleteResponse(
+
+    val status: Boolean,
+
+    val message: String
+) {
+
+    companion object{
+        fun resumeDeleteCreate(status: Boolean, fileName: String) : FileDeleteResponse {
+            return FileDeleteResponse(
+                status,
+                "이력서 파일 : $fileName 삭제에 성공했습니다."
+            )
+        }
+
+        fun portfolioDeleteCreate(status: Boolean, fileName: String) : FileDeleteResponse {
+            return FileDeleteResponse(
+                status,
+                "포트폴리오 파일 : $fileName 삭제에 성공했습니다."
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/zighang/scrap/presentation/ScrapController.kt
+++ b/src/main/kotlin/com/zighang/scrap/presentation/ScrapController.kt
@@ -8,12 +8,14 @@ import com.zighang.scrap.dto.request.UpsertScrapRequest
 import com.zighang.scrap.dto.response.DashboardResponse
 import com.zighang.scrap.presentation.swagger.ScrapSwagger
 import com.zighang.scrap.service.ScrapService
+import com.zighang.scrap.value.FileType
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
 
 @RestController
 @RequestMapping("/scrap")
@@ -55,6 +57,25 @@ class ScrapController(
         @RequestBody @Valid request: ScrapDeleteRequest
     ) {
         scrapService.scrapDeleteService(customUserDetails, request.idList)
+    }
+
+    @PostMapping("/{scrapId}/file/{fileType}")
+    override fun fileUpload(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @PathVariable scrapId: Long,
+        @PathVariable fileType: FileType,
+        file: MultipartFile
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun fileDelete(
+        customUserDetails: CustomUserDetails,
+        scrapId: Long,
+        fileType: FileType,
+        file: MultipartFile
+    ) {
+        TODO("Not yet implemented")
     }
 
 }

--- a/src/main/kotlin/com/zighang/scrap/presentation/ScrapController.kt
+++ b/src/main/kotlin/com/zighang/scrap/presentation/ScrapController.kt
@@ -6,12 +6,15 @@ import com.zighang.core.presentation.RestResponse
 import com.zighang.scrap.dto.request.ScrapDeleteRequest
 import com.zighang.scrap.dto.request.UpsertScrapRequest
 import com.zighang.scrap.dto.response.DashboardResponse
+import com.zighang.scrap.dto.response.FileDeleteResponse
+import com.zighang.scrap.dto.response.FileResponse
 import com.zighang.scrap.presentation.swagger.ScrapSwagger
 import com.zighang.scrap.service.ScrapService
 import com.zighang.scrap.value.FileType
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
@@ -59,23 +62,32 @@ class ScrapController(
         scrapService.scrapDeleteService(customUserDetails, request.idList)
     }
 
-    @PostMapping("/{scrapId}/file/{fileType}")
+    @PostMapping(value = ["/{scrapId}/file/{fileType}"], consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     override fun fileUpload(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails,
         @PathVariable scrapId: Long,
         @PathVariable fileType: FileType,
-        file: MultipartFile
-    ) {
-        TODO("Not yet implemented")
+        @RequestPart(name = "file") file: MultipartFile
+    ): ResponseEntity<RestResponse<FileResponse>> {
+        return ResponseEntity.ok(
+            RestResponse<FileResponse>(
+                scrapService.uploadFile(customUserDetails, scrapId, file, fileType)
+            )
+        )
     }
 
+    @DeleteMapping("/{scrapId}/file/{fileType}")
     override fun fileDelete(
-        customUserDetails: CustomUserDetails,
-        scrapId: Long,
-        fileType: FileType,
-        file: MultipartFile
-    ) {
-        TODO("Not yet implemented")
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @PathVariable scrapId: Long,
+        @PathVariable fileType: FileType,
+        @RequestParam fileUrl: String
+    ) : ResponseEntity<RestResponse<FileDeleteResponse>>{
+        return ResponseEntity.ok(
+            RestResponse<FileDeleteResponse>(
+                scrapService.deleteFile(customUserDetails, scrapId, fileUrl, fileType)
+            )
+        )
     }
 
 }

--- a/src/main/kotlin/com/zighang/scrap/presentation/swagger/ScrapSwagger.kt
+++ b/src/main/kotlin/com/zighang/scrap/presentation/swagger/ScrapSwagger.kt
@@ -6,6 +6,7 @@ import com.zighang.core.presentation.RestResponse
 import com.zighang.scrap.dto.request.ScrapDeleteRequest
 import com.zighang.scrap.dto.request.UpsertScrapRequest
 import com.zighang.scrap.dto.response.DashboardResponse
+import com.zighang.scrap.value.FileType
 import io.swagger.v3.oas.annotations.Operation
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
@@ -13,6 +14,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.multipart.MultipartFile
 
 interface ScrapSwagger {
     @Operation(
@@ -40,5 +42,29 @@ interface ScrapSwagger {
     fun deleteScraps(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails,
         @RequestBody @Valid request: ScrapDeleteRequest
+    )
+
+    @Operation(
+        summary = "스크랩에 이력서/포트폴리오 저장",
+        description = "유저가 저장한 스크랩에 이력서/포트폴리오 파일을 저장합니다.",
+        operationId = "/scrap/{scrapId}/files/{fileType}",
+    )
+    fun fileUpload(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @PathVariable scrapId: Long,
+        @PathVariable fileType: FileType,
+        @RequestParam("file") file: MultipartFile
+    )
+
+    @Operation(
+        summary = "스크랩에 이력서/포트폴리오 삭제",
+        description = "유저가 저장한 이력서/포트폴리오 파일을 삭제합니다.",
+        operationId = "/scrap/{scrapId}/files/{fileType}",
+    )
+    fun fileDelete(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails,
+        @PathVariable scrapId: Long,
+        @PathVariable fileType: FileType,
+        @RequestParam("file") file: MultipartFile
     )
 }

--- a/src/main/kotlin/com/zighang/scrap/presentation/swagger/ScrapSwagger.kt
+++ b/src/main/kotlin/com/zighang/scrap/presentation/swagger/ScrapSwagger.kt
@@ -6,9 +6,12 @@ import com.zighang.core.presentation.RestResponse
 import com.zighang.scrap.dto.request.ScrapDeleteRequest
 import com.zighang.scrap.dto.request.UpsertScrapRequest
 import com.zighang.scrap.dto.response.DashboardResponse
+import com.zighang.scrap.dto.response.FileDeleteResponse
+import com.zighang.scrap.dto.response.FileResponse
 import com.zighang.scrap.value.FileType
 import io.swagger.v3.oas.annotations.Operation
 import jakarta.validation.Valid
+import org.springframework.data.repository.query.Param
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
@@ -54,7 +57,7 @@ interface ScrapSwagger {
         @PathVariable scrapId: Long,
         @PathVariable fileType: FileType,
         @RequestParam("file") file: MultipartFile
-    )
+    ) : ResponseEntity<RestResponse<FileResponse>>
 
     @Operation(
         summary = "스크랩에 이력서/포트폴리오 삭제",
@@ -65,6 +68,6 @@ interface ScrapSwagger {
         @AuthenticationPrincipal customUserDetails: CustomUserDetails,
         @PathVariable scrapId: Long,
         @PathVariable fileType: FileType,
-        @RequestParam("file") file: MultipartFile
-    )
+        @RequestParam fileUrl: String
+    ) : ResponseEntity<RestResponse<FileDeleteResponse>>
 }

--- a/src/main/kotlin/com/zighang/scrap/repository/ScrapRepository.kt
+++ b/src/main/kotlin/com/zighang/scrap/repository/ScrapRepository.kt
@@ -10,5 +10,5 @@ interface ScrapRepository : JpaRepository<Scrap, Long> {
 
     fun findByJobPostingIdAndMemberId(jobPostingId : Long, memberId : Long) : Scrap?
 
-    fun findByScrapIdAndMemberId(scorrId : Long, memberId : Long) : Scrap?
+    fun findByIdAndMemberId(id : Long, memberId : Long) : Scrap?
 }

--- a/src/main/kotlin/com/zighang/scrap/repository/ScrapRepository.kt
+++ b/src/main/kotlin/com/zighang/scrap/repository/ScrapRepository.kt
@@ -9,4 +9,6 @@ interface ScrapRepository : JpaRepository<Scrap, Long> {
     fun findAllByMemberId(memberId : Long, pageable: Pageable) : Page<Scrap>
 
     fun findByJobPostingIdAndMemberId(jobPostingId : Long, memberId : Long) : Scrap?
+
+    fun findByScrapIdAndMemberId(scorrId : Long, memberId : Long) : Scrap?
 }

--- a/src/main/kotlin/com/zighang/scrap/service/ScrapService.kt
+++ b/src/main/kotlin/com/zighang/scrap/service/ScrapService.kt
@@ -167,9 +167,7 @@ class ScrapService(
         fileType: FileType
     ): FileDeleteResponse {
         val scrap = getScrapByScrapIdAndMemberId(scrapId, customUserDetails.getId())
-
-        val currentUrl = fileType.urlGetter(scrap)
-        if (currentUrl != fileUrl) {
+        if (fileType.urlGetter(scrap) != fileUrl) {
             throw DomainException(GlobalErrorCode.IS_NOT_YOUR_FILE)
         }
 
@@ -195,7 +193,7 @@ class ScrapService(
 
     @Transactional(readOnly = true)
     fun findScrapByScrapIdAndMemberId(scrapId: Long, memberId: Long)
-        = scrapRepository.findByScrapIdAndMemberId(scrapId, memberId)
+        = scrapRepository.findByIdAndMemberId(scrapId, memberId)
 
     @Transactional(readOnly = true)
     fun getScrapByScrapIdAndMemberId(scrapId: Long, memberId: Long)

--- a/src/main/kotlin/com/zighang/scrap/service/ScrapService.kt
+++ b/src/main/kotlin/com/zighang/scrap/service/ScrapService.kt
@@ -11,11 +11,13 @@ import com.zighang.memo.repository.MemoRepository
 import com.zighang.scrap.dto.request.JobScrapedEvent
 import com.zighang.scrap.dto.request.UpsertScrapRequest
 import com.zighang.scrap.dto.response.DashboardResponse
+import com.zighang.scrap.dto.response.FileDeleteResponse
 import com.zighang.scrap.dto.response.FileResponse
 import com.zighang.scrap.dto.response.JobPostingResponse
 import com.zighang.scrap.entity.Scrap
 import com.zighang.scrap.infrastructure.JobAnalysisEventProducer
 import com.zighang.scrap.repository.ScrapRepository
+import com.zighang.scrap.value.FileType
 import lombok.extern.slf4j.Slf4j
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
@@ -25,6 +27,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.support.TransactionSynchronization
 import org.springframework.transaction.support.TransactionSynchronizationManager
+import org.springframework.web.multipart.MultipartFile
 
 @Service
 @Slf4j
@@ -46,6 +49,9 @@ class ScrapService(
             TransactionSynchronizationManager.registerSynchronization(
                 object : TransactionSynchronization {
                     override fun afterCommit() {
+                        
+                        // TODO: 카드 뽑기 커밋 후 추가
+                        // 레디스로 동일 큐 내 같은 데이터 저장 안되도록 방어
                         val event = JobScrapedEvent(
                             id = jobPosting.id!!,
                             ocrData = jobPosting.ocrData
@@ -137,6 +143,44 @@ class ScrapService(
         deleteByIdList(idList)
     }
 
+    @Transactional
+    fun uploadFile(
+        customUserDetails: CustomUserDetails,
+        scrapId: Long,
+        file: MultipartFile,
+        fileType: FileType
+    ): FileResponse {
+        val scrap = getScrapByScrapIdAndMemberId(scrapId, customUserDetails.getId())
+
+        val fileUrl = fileType.uploadFunction(objectStorageService, file, scrapId)
+
+        fileType.urlSetter(scrap, fileUrl)
+
+        return FileResponse.create(fileUrl, file.originalFilename)
+    }
+
+    @Transactional
+    fun deleteFile(
+        customUserDetails: CustomUserDetails,
+        scrapId: Long,
+        fileUrl: String,
+        fileType: FileType
+    ): FileDeleteResponse {
+        val scrap = getScrapByScrapIdAndMemberId(scrapId, customUserDetails.getId())
+
+        val currentUrl = fileType.urlGetter(scrap)
+        if (currentUrl != fileUrl) {
+            throw DomainException(GlobalErrorCode.IS_NOT_YOUR_FILE)
+        }
+
+        objectStorageService.deleteFile(fileUrl)
+        val originalFileName = objectStorageService.extractOriginalFilenameFromS3(fileUrl)
+            ?: throw DomainException(GlobalErrorCode.CANNOT_EXTRACT_FILENAME)
+
+        fileType.urlSetter(scrap, null)
+        return fileType.responseFactory(true, originalFileName)
+    }
+
     @Transactional(readOnly = true)
     fun getById(id : Long) = findById(id) ?: throw DomainException(GlobalErrorCode.NOT_EXIST_SCRAP)
 
@@ -148,4 +192,12 @@ class ScrapService(
 
     @Transactional
     fun deleteByIdList(idList: List<Long>) = scrapRepository.deleteAllById(idList)
+
+    @Transactional(readOnly = true)
+    fun findScrapByScrapIdAndMemberId(scrapId: Long, memberId: Long)
+        = scrapRepository.findByScrapIdAndMemberId(scrapId, memberId)
+
+    @Transactional(readOnly = true)
+    fun getScrapByScrapIdAndMemberId(scrapId: Long, memberId: Long)
+        = findScrapByScrapIdAndMemberId(scrapId, memberId) ?: throw DomainException(GlobalErrorCode.NOT_EXIST_SCRAP)
 }

--- a/src/main/kotlin/com/zighang/scrap/service/ScrapService.kt
+++ b/src/main/kotlin/com/zighang/scrap/service/ScrapService.kt
@@ -65,8 +65,6 @@ class ScrapService(
                 }
             }.apply {
                 jobPostingId = upsertScrapRequest.jobPostingId
-                resumeUrl = upsertScrapRequest.resumeUrl
-                portfolioUrl = upsertScrapRequest.portfolioUrl
             }.let {
                 savedScrap -> save(savedScrap)
             }
@@ -74,8 +72,8 @@ class ScrapService(
             Scrap.create(
                 upsertScrapRequest.jobPostingId,
                 customUserDetails.getId(),
-                upsertScrapRequest.resumeUrl,
-                upsertScrapRequest.portfolioUrl
+                null,
+                null
             )
         )
     }

--- a/src/main/kotlin/com/zighang/scrap/value/FileType.kt
+++ b/src/main/kotlin/com/zighang/scrap/value/FileType.kt
@@ -1,0 +1,26 @@
+package com.zighang.scrap.value
+
+import com.zighang.core.application.ObjectStorageService
+import com.zighang.scrap.dto.response.FileDeleteResponse
+import com.zighang.scrap.entity.Scrap
+import org.springframework.web.multipart.MultipartFile
+
+enum class FileType(
+    val urlGetter: (Scrap) -> String?,
+    val urlSetter: (Scrap, String?) -> Unit,
+    val responseFactory: (Boolean, String) -> FileDeleteResponse,
+    val uploadFunction: (ObjectStorageService, MultipartFile, Long) -> String
+) {
+    RESUME(
+        { it.resumeUrl },
+        { scrap, _ -> scrap.resumeUrl = null },
+        { success, filename -> FileDeleteResponse.resumeDeleteCreate(success, filename) },
+        { storage, file, scrapId -> storage.uploadResumeFile(file, scrapId) }
+    ),
+    PORTFOLIO(
+        { it.portfolioUrl },
+        { scrap, _ -> scrap.portfolioUrl = null },
+        { success, filename -> FileDeleteResponse.portfolioDeleteCreate(success, filename) },
+        { storage, file, scrapId -> storage.uploadPortpolioFile(file, scrapId) }
+    )
+}

--- a/src/main/kotlin/com/zighang/scrap/value/FileType.kt
+++ b/src/main/kotlin/com/zighang/scrap/value/FileType.kt
@@ -13,13 +13,13 @@ enum class FileType(
 ) {
     RESUME(
         { it.resumeUrl },
-        { scrap, _ -> scrap.resumeUrl = null },
+        { scrap, url -> scrap.resumeUrl = url },
         { success, filename -> FileDeleteResponse.resumeDeleteCreate(success, filename) },
         { storage, file, scrapId -> storage.uploadResumeFile(file, scrapId) }
     ),
     PORTFOLIO(
         { it.portfolioUrl },
-        { scrap, _ -> scrap.portfolioUrl = null },
+        { scrap, url -> scrap.portfolioUrl = url },
         { success, filename -> FileDeleteResponse.portfolioDeleteCreate(success, filename) },
         { storage, file, scrapId -> storage.uploadPortpolioFile(file, scrapId) }
     )


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 이력서 업로드 및 삭제 기능을 분리함
- dto내 불필요 필드 제거

---

## ✏️ 관련 이슈
#40 

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 스크랩에 이력서/포트폴리오 파일 업로드·삭제 기능 추가(업로드: multipart 파일, 삭제: fileUrl 파라미터). 처리 결과와 메시지 반환.
* API 변경
  * UpsertScrapRequest에서 resumeUrl, portfolioUrl 필드 제거. 파일은 전용 업로드 엔드포인트로 관리.
* 오류 처리
  * 본인 파일만 삭제 가능, 원본 파일명 추출 실패에 대한 에러 코드 추가로 응답 메시지 명확화.
* 문서
  * 스크랩 파일 업로드/삭제 엔드포인트를 Swagger에 추가 및 예시/파라미터 명세 반영.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->