### PR TITLE
Feat(#53) 카드 뽑기 시 스크랩 수 제한

### DIFF
--- a/src/main/kotlin/com/zighang/card/dto/RemainScrapResponse.kt
+++ b/src/main/kotlin/com/zighang/card/dto/RemainScrapResponse.kt
@@ -1,0 +1,13 @@
+package com.zighang.card.dto
+
+data class RemainScrapResponse(
+    var scrapCount : Long
+) {
+    companion object {
+        fun create(scrapCount: Long) : RemainScrapResponse {
+            return RemainScrapResponse(
+                scrapCount =  scrapCount
+            );
+        }
+    }
+}

--- a/src/main/kotlin/com/zighang/card/facade/CardFacade.kt
+++ b/src/main/kotlin/com/zighang/card/facade/CardFacade.kt
@@ -1,12 +1,17 @@
 package com.zighang.card.facade
 
 import com.zighang.card.dto.CardContentResponse
+import com.zighang.card.dto.RemainScrapResponse
 import com.zighang.card.service.CardService
 import com.zighang.card.value.CardPosition
+import com.zighang.core.exception.DomainException
+import com.zighang.core.exception.GlobalErrorCode
 import com.zighang.core.infrastructure.CustomUserDetails
 import com.zighang.jobposting.service.JobPostingService
 import com.zighang.member.service.MemberService
 import com.zighang.member.service.OnboardingService
+import com.zighang.scrap.service.ScrapService
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
 @Component
@@ -14,11 +19,22 @@ class CardFacade(
     private val cardService: CardService,
     private val memberService: MemberService,
     private val onboardingService: OnboardingService,
-    private val jobPostingService: JobPostingService
+    private val jobPostingService: JobPostingService,
+    private val scrapService: ScrapService,
 ) {
+    @Value("\${scrap.count_limit}")
+    private lateinit var limitScrapCount: String
+
     fun createCard(customUserDetails: CustomUserDetails) {
         //직군, 직무 뽑아오기
         val member = memberService.getById(customUserDetails.getId())
+        val scrapCount = scrapService.getScrapCount(member.id)
+        val getCardScrapCount = cardService.getCardScrapCount(member.id)
+
+        if(scrapCount < getCardScrapCount + limitScrapCount.toLong()) {
+            throw DomainException(GlobalErrorCode.LIMIT_CARD)
+        }
+
         val onboarding = onboardingService.getById(member.onboardingId!!)
         val jobCategory = onboarding.jobCategory
         val jobRole = onboarding.jobRole
@@ -29,6 +45,8 @@ class CardFacade(
         cardService.evict(member.id)
         //카드 3개 생성
         cardService.saveTop3Ids(member.id, top3JobPosting)
+        //스크랩 수 레디스에 저장
+        cardService.upsertCardScrapCount(member.id, scrapCount)
     }
 
     fun getCard(customUserDetails: CustomUserDetails, position: CardPosition): CardContentResponse {
@@ -48,5 +66,8 @@ class CardFacade(
         return cardService.getOpenCardList(customUserDetails.getId());
     }
 
+    fun showScrap(customUserDetails: CustomUserDetails): RemainScrapResponse {
+        return cardService.getScrapForCard(customUserDetails.getId())
+    }
 
 }

--- a/src/main/kotlin/com/zighang/card/presentation/CardController.kt
+++ b/src/main/kotlin/com/zighang/card/presentation/CardController.kt
@@ -64,7 +64,8 @@ class CardController(
     }
 
     @GetMapping("/remain-scrap")
-    override fun showScrap(customUserDetails: CustomUserDetails): ResponseEntity<RestResponse<RemainScrapResponse>> {
+    override fun showScrap(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails): ResponseEntity<RestResponse<RemainScrapResponse>> {
         return ResponseEntity.ok(
             RestResponse(
                 cardFacade.showScrap(customUserDetails)

--- a/src/main/kotlin/com/zighang/card/presentation/CardController.kt
+++ b/src/main/kotlin/com/zighang/card/presentation/CardController.kt
@@ -2,6 +2,7 @@ package com.zighang.card.presentation
 
 import com.zighang.card.dto.CardContentResponse
 import com.zighang.card.dto.GetCardPositionRequest
+import com.zighang.card.dto.RemainScrapResponse
 import com.zighang.card.facade.CardFacade
 import com.zighang.card.presentation.swagger.CardSwagger
 import com.zighang.core.infrastructure.CustomUserDetails
@@ -58,6 +59,15 @@ class CardController(
         return ResponseEntity.ok(
             RestResponse(
                 cardFacade.showOpenList(customUserDetails)
+            )
+        )
+    }
+
+    @GetMapping("/remain-scrap")
+    override fun showScrap(customUserDetails: CustomUserDetails): ResponseEntity<RestResponse<RemainScrapResponse>> {
+        return ResponseEntity.ok(
+            RestResponse(
+                cardFacade.showScrap(customUserDetails)
             )
         )
     }

--- a/src/main/kotlin/com/zighang/card/presentation/swagger/CardSwagger.kt
+++ b/src/main/kotlin/com/zighang/card/presentation/swagger/CardSwagger.kt
@@ -2,6 +2,7 @@ package com.zighang.card.presentation.swagger
 
 import com.zighang.card.dto.CardContentResponse
 import com.zighang.card.dto.GetCardPositionRequest
+import com.zighang.card.dto.RemainScrapResponse
 import com.zighang.core.infrastructure.CustomUserDetails
 import com.zighang.core.presentation.RestResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -47,4 +48,13 @@ interface CardSwagger {
     fun showOpenCard(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails
     ) : ResponseEntity<RestResponse<List<CardContentResponse>>>
+
+    @Operation(
+        summary = "스크랩 수 조회",
+        description = "스크랩 수를 조회한다. (0부터 3까지)",
+        operationId = "/remain-scrap"
+    )
+    fun showScrap(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails
+    ) : ResponseEntity<RestResponse<RemainScrapResponse>>
 }

--- a/src/main/kotlin/com/zighang/card/service/CardService.kt
+++ b/src/main/kotlin/com/zighang/card/service/CardService.kt
@@ -33,9 +33,7 @@ class CardService(
     private lateinit var maxCount : String;
 
     fun getCardScrapCount(memberId: Long) : Long {
-       return Optional.ofNullable(redisTemplate.opsForValue()[scrapKey(memberId)])
-            .map(java.lang.Long::valueOf)
-            .orElse(0L)
+        return redisTemplate.opsForValue().get(scrapKey(memberId))?.toLong() ?: 0L
     }
 
     fun upsertCardScrapCount(memberId: Long, scrapCount: Long) {

--- a/src/main/kotlin/com/zighang/card/service/CardService.kt
+++ b/src/main/kotlin/com/zighang/card/service/CardService.kt
@@ -8,21 +8,39 @@ import com.zighang.card.value.CardPosition
 import com.zighang.core.exception.DomainException
 import com.zighang.core.exception.GlobalErrorCode
 import com.zighang.jobposting.entity.JobPosting
+import com.zighang.scrap.service.ScrapService
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
 import java.time.Duration
 import java.time.LocalDateTime
+import java.util.*
 
 
 @Service
 class CardService(
     private val redisTemplate: RedisTemplate<String, String>,
     private val objectMapper: ObjectMapper,
+    private val scrapService: ScrapService
 ) {
     private val prefix = "top3JobPosting:"
     private fun servedKey(memberId: Long) = "card:served:$memberId"
 
     private fun key(memberId: Long) = "$prefix$memberId"
+    private fun scrapKey(memberId: Long) = "scrap:$memberId"
+
+    @Value("\${scrap.count_limit}")
+    private lateinit var maxCount : String;
+
+    fun getCardScrapCount(memberId: Long) : Long {
+       return Optional.ofNullable(redisTemplate.opsForValue()[scrapKey(memberId)])
+            .map(java.lang.Long::valueOf)
+            .orElse(0L)
+    }
+
+    fun upsertCardScrapCount(memberId: Long, scrapCount: Long) {
+        redisTemplate.opsForValue().set(scrapKey(memberId), scrapCount.toString())
+    }
 
     fun saveTop3Ids(memberId: Long, ids: List<CardRedis>) {
         require(ids.size == 3) { "Top3는 정확히 3개여야 합니다." }
@@ -149,5 +167,15 @@ class CardService(
         val k = key(memberId)
         val raw = redisTemplate.opsForList().range(k, 0, -1).orEmpty()
         return raw.map { objectMapper.readValue(it, CardRedis::class.java) }
+    }
+
+    fun getScrapForCard(memberId : Long): RemainScrapResponse {
+        val dbCount = scrapService.getScrapCount(memberId)
+        val redisCount = getCardScrapCount(memberId)
+
+        val diff = dbCount - redisCount
+        return RemainScrapResponse.create(
+            diff.coerceAtMost(maxCount.toLong())
+        )
     }
 }

--- a/src/main/kotlin/com/zighang/core/exception/GlobalErrorCode.kt
+++ b/src/main/kotlin/com/zighang/core/exception/GlobalErrorCode.kt
@@ -22,7 +22,8 @@ enum class GlobalErrorCode(
     CLOVA_API_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "클로바 API 연결에 실패했습니다."),
     NOT_CONVERT_JSON_TO_OBJECT(HttpStatus.INTERNAL_SERVER_ERROR, "JSON 변환에 실패했습니다."),
     NOT_EXIST_MEMBER_CARD(HttpStatus.BAD_REQUEST, "이 멤버는 카드를 지니고 있지 않습니다. 카드 갱신/생성을 하세요"),
-    NOT_FOUND_CARD(HttpStatus.NOT_FOUND, "해당 카드 공고는 존재하지 않습니다.");
+    NOT_FOUND_CARD(HttpStatus.NOT_FOUND, "해당 카드 공고는 존재하지 않습니다."),
+    LIMIT_CARD(HttpStatus.BAD_REQUEST, "공고 스크랩 수가 부족합니다.");
 
     override fun toException(): DomainException {
         return DomainException(this)

--- a/src/main/kotlin/com/zighang/jobposting/service/JobPostingService.kt
+++ b/src/main/kotlin/com/zighang/jobposting/service/JobPostingService.kt
@@ -18,6 +18,7 @@ class JobPostingService(
     private val cardService: CardService
 ) {
     fun top3ByJob(depthOne: String?, depthTwo: String?): List<CardRedis> {
+
         val page3 = PageRequest.of(0, 3)
 
         val first = jobPostingRepository.findTopJobPostingsByDepths(depthOne, depthTwo, page3)

--- a/src/main/kotlin/com/zighang/scrap/repository/ScrapRepository.kt
+++ b/src/main/kotlin/com/zighang/scrap/repository/ScrapRepository.kt
@@ -19,4 +19,6 @@ interface ScrapRepository : JpaRepository<Scrap, Long> {
 
     @Query("SELECT s.memberId FROM Scrap s WHERE s.memberId IN :memberIds GROUP BY s.memberId HAVING COUNT(s.memberId) >= 4")
     fun findMemberIdsWithMoreThanFourScraps(memberIds: List<Long>): List<Long>
+
+    fun countByMemberId(memberId: Long) : Long
 }

--- a/src/main/kotlin/com/zighang/scrap/service/ScrapService.kt
+++ b/src/main/kotlin/com/zighang/scrap/service/ScrapService.kt
@@ -139,6 +139,13 @@ class ScrapService(
         return PageImpl(dashboards, pageable, scrapPage.totalElements)
     }
 
+    @Transactional(readOnly = true)
+    fun getScrapCount(memberId: Long) : Long{
+        return scrapRepository.countByMemberId(memberId);
+    }
+
+
+
     private fun isAnalysisNeed(jobPosting: JobPosting) : Boolean {
         return jobPosting.qualification.isNullOrBlank() || jobPosting.preferentialTreatment.isNullOrBlank()
     }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 사용자가 카드를 몇 번 뽑았는지 저장
- 스크랩수 3개 이하일 때 카드를 뽑으면 에러 반환

---

## ✏️ 관련 이슈
#53 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 잔여 스크랩 수 조회 기능 추가(0~3). 내 스크랩 남은 개수를 확인할 수 있습니다.
  - 카드 생성 시 스크랩 수가 부족하면 생성이 제한되며, 알기 쉬운 오류 메시지가 제공됩니다.
- Documentation
  - 잔여 스크랩 수 조회 엔드포인트가 API 명세에 추가되었습니다.
- Chores
  - 내부 보안 리소스 업데이트(서비스 동작에는 영향 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->