### PR TITLE
[feat] 온보딩 여러개 받도록 업데이트 #59

### DIFF
--- a/src/main/kotlin/com/zighang/card/facade/CardFacade.kt
+++ b/src/main/kotlin/com/zighang/card/facade/CardFacade.kt
@@ -37,8 +37,8 @@ class CardFacade(
 
         val onboarding = onboardingService.getById(member.onboardingId!!)
         val jobCategory = onboarding.jobCategory
-        val jobRole = onboarding.jobRole
-
+//        val jobRole = onboarding.jobRole
+        val jobRole = "생산" // Todo 직무 여러 개도 고려하도록 수정
         val top3JobPosting = jobPostingService.top3ByJob(jobCategory, jobRole)
 
         //이전 카드 초기화
@@ -59,7 +59,8 @@ class CardFacade(
     fun replace(customUserDetails: CustomUserDetails, position: CardPosition) : Boolean{
         val member = memberService.getById(customUserDetails.getId())
         val onboarding = onboardingService.getById(member.onboardingId!!)
-        return jobPostingService.replace(member.id, onboarding.jobCategory, onboarding.jobRole,position);
+        val jobRole = "생산" // Todo 직무 여러 개도 고려하도록 수정
+        return jobPostingService.replace(member.id, onboarding.jobCategory, jobRole,position);
     }
 
     fun showOpenList(customUserDetails: CustomUserDetails): List<CardContentResponse> {

--- a/src/main/kotlin/com/zighang/member/dto/request/OnboardingRequest.kt
+++ b/src/main/kotlin/com/zighang/member/dto/request/OnboardingRequest.kt
@@ -7,8 +7,8 @@ data class OnboardingRequest(
     @Schema(description = "직군", example = "IT")
     val jobCategory: String,
 
-    @Schema(description = "직무", example = "백엔드")
-    val jobRole: String,
+    @Schema(description = "직무", example = "[\"백엔드\", \"프론트엔드\"]")
+    val jobRole: List<String>,
 
     @Schema(description = "연차", example = "YEAR_0(0),\n" +
             "    YEAR_1(1),\n" +
@@ -47,6 +47,6 @@ data class OnboardingRequest(
     @Schema(description = "학교", example = "건국대학교")
     val school: String,
 
-    @Schema(description = "희망 기업", example = "현대")
-    val targetCompany : String
+    @Schema(description = "전공", example = "현대")
+    val major : String
 )

--- a/src/main/kotlin/com/zighang/member/entity/JobRole.kt
+++ b/src/main/kotlin/com/zighang/member/entity/JobRole.kt
@@ -1,0 +1,30 @@
+package com.zighang.member.entity
+
+import com.zighang.core.infrastructure.jpa.shared.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "jobRole")
+class JobRole(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Column(name = "onboarding_id")
+    var onboardingId : Long,
+
+    @Column(name = "job_role")
+    var jobRole : String
+) : BaseEntity() {
+    companion object {
+        fun create(
+            onboardingId: Long,
+            jobRole: String
+        ) : JobRole {
+            return JobRole(
+                onboardingId = onboardingId,
+                jobRole =  jobRole
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/zighang/member/entity/Onboarding.kt
+++ b/src/main/kotlin/com/zighang/member/entity/Onboarding.kt
@@ -14,9 +14,6 @@ class Onboarding (
     @Column(name = "job_category", nullable = false)
     var jobCategory : String,
 
-    @Column(name = "job_role", nullable = false)
-    var jobRole : String,
-
     @Enumerated(EnumType.STRING)
     @Column(name = "career_year", nullable = false)
     var careerYear : CareerYear,
@@ -29,42 +26,42 @@ class Onboarding (
     @Enumerated(EnumType.STRING)
     var school : School,
 
-    @Column(name = "target_company", nullable = false)
-    var targetCompany : String,
+    @Column(name = "major", nullable = false)
+    var major : String,
+
+    @Column(name = "jobRole", nullable = false)
+    var jobRole : String
 ) : BaseEntity() {
     companion object {
         fun create(
             jobCategory: String,
-            jobRole: String,
             careerYear: CareerYear,
             region: Region,
             school: School,
-            targetCompany: String
+            major: String
         ): Onboarding {
             return Onboarding(
                 jobCategory = jobCategory,
-                jobRole = jobRole,
                 careerYear = careerYear,
                 region = region,
                 school = school,
-                targetCompany = targetCompany
+                major = major,
+                jobRole = "생산" // Todo 임시방편
             )
         }
     }
 
     fun update(
         jobCategory: String,
-        jobRole: String,
         careerYear: CareerYear,
         region: Region,
         school: School,
-        targetCompany: String
+        major: String
     ) {
         this.jobCategory = jobCategory
-        this.jobRole = jobRole
         this.careerYear = careerYear
         this.region = region
         this.school = school
-        this.targetCompany = targetCompany
+        this.major = major
     }
 }

--- a/src/main/kotlin/com/zighang/member/facade/MemberFacade.kt
+++ b/src/main/kotlin/com/zighang/member/facade/MemberFacade.kt
@@ -15,10 +15,6 @@ class MemberFacade(
     @Transactional
     fun onboarding(customUserDetails: CustomUserDetails, onboardingRequest: OnboardingRequest) {
         val member = memberService.getById(customUserDetails.getId())
-        member.onboardingId
-            ?.let { onboardingService.getById(it).also { o -> onboardingService.updateOnboarding(o, onboardingRequest) } }
-            ?: onboardingService.createOnboarding(onboardingRequest).also { o ->
-                memberService.completeOnboarding(member, o)
-            }
+        onboardingService.upsertOnboarding(member.onboardingId, onboardingRequest)
     }
 }

--- a/src/main/kotlin/com/zighang/member/repository/JobRoleRepository.kt
+++ b/src/main/kotlin/com/zighang/member/repository/JobRoleRepository.kt
@@ -1,0 +1,8 @@
+package com.zighang.member.repository
+
+import com.zighang.member.entity.JobRole
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface JobRoleRepository : JpaRepository<JobRole, Long> {
+    fun deleteByOnboardingId(onboardingId : Long)
+}

--- a/src/main/kotlin/com/zighang/member/service/OnboardingService.kt
+++ b/src/main/kotlin/com/zighang/member/service/OnboardingService.kt
@@ -3,8 +3,10 @@ package com.zighang.member.service
 import com.zighang.core.exception.DomainException
 import com.zighang.core.exception.GlobalErrorCode
 import com.zighang.member.dto.request.OnboardingRequest
+import com.zighang.member.entity.JobRole
 import com.zighang.member.entity.Onboarding
 import com.zighang.member.entity.value.School
+import com.zighang.member.repository.JobRoleRepository
 import com.zighang.member.repository.OnboardingRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -12,21 +14,9 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class OnboardingService(
-    private val onboardingRepository: OnboardingRepository
+    private val onboardingRepository: OnboardingRepository,
+    private val jobRoleRepository: JobRoleRepository
 ) {
-    @Transactional
-    fun createOnboarding(onboardingRequest: OnboardingRequest) : Onboarding {
-        val onboarding = Onboarding.create(
-            onboardingRequest.jobCategory,
-            onboardingRequest.jobRole,
-            onboardingRequest.careerYear,
-            onboardingRequest.region,
-            School.fromSchoolName(onboardingRequest.school),
-            onboardingRequest.targetCompany
-        )
-        return onboardingRepository.save(onboarding)
-    }
-
     @Transactional(readOnly = true)
     fun findById(id : Long) : Onboarding? {
         return onboardingRepository.findByIdOrNull(id)
@@ -38,14 +28,40 @@ class OnboardingService(
     }
 
     @Transactional
-    fun updateOnboarding(onboarding: Onboarding, onboardingRequest: OnboardingRequest) {
-        onboarding.update(
-            onboardingRequest.jobCategory,
-            onboardingRequest.jobRole,
-            onboardingRequest.careerYear,
-            onboardingRequest.region,
-            School.fromSchoolName(onboardingRequest.school),
-            onboardingRequest.targetCompany
-        )
+    fun upsertOnboarding(onboardingId: Long?, onboardingRequest: OnboardingRequest) {
+        val onboarding = if (onboardingId == null) {
+            Onboarding.create(
+                jobCategory = onboardingRequest.jobCategory,
+                careerYear = onboardingRequest.careerYear,
+                region = onboardingRequest.region,
+                school = School.fromSchoolName(onboardingRequest.school),
+                major = onboardingRequest.major
+            ).let(onboardingRepository::save)
+        } else {
+            val found = onboardingRepository.findById(onboardingId)
+                .orElseThrow { NoSuchElementException("Onboarding not found: $onboardingId") }
+
+            found.update(
+                jobCategory = onboardingRequest.jobCategory,
+                careerYear = onboardingRequest.careerYear,
+                region = onboardingRequest.region,
+                school = School.fromSchoolName(onboardingRequest.school),
+                major = onboardingRequest.major
+            )
+            found
+        }
+
+        jobRoleRepository.deleteByOnboardingId(onboarding.id)
+
+        val rolesToSave = onboardingRequest.jobRole
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .distinct()
+            .map { role -> JobRole.create(onboardingId = onboarding.id, jobRole = role) }
+
+        if (rolesToSave.isNotEmpty()) {
+            jobRoleRepository.saveAll(rolesToSave)
+        }
+
     }
 }

--- a/src/main/kotlin/com/zighang/scrap/dto/response/alumni/SimilarAlumniDetailResponseDto.kt
+++ b/src/main/kotlin/com/zighang/scrap/dto/response/alumni/SimilarAlumniDetailResponseDto.kt
@@ -20,7 +20,7 @@ data class SimilarAlumniDetailResponseDto(
             return SimilarAlumniDetailResponseDto(
                 member.id,
                 member.name,
-                onboarding.targetCompany,
+                onboarding.major,
                 onboarding.jobRole,
                 list
             )


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 공고 여러 개 받도록 업데이트

---

## ✏️ 관련 이슈
#59 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 온보딩에서 ‘희망 기업’ 대신 ‘전공’을 입력·표시합니다.
  * 온보딩에서 직무를 여러 개 선택할 수 있습니다.
* 개선
  * 온보딩 생성/수정 절차를 하나로 통합해 저장 과정이 더 매끄럽고 신뢰성 있게 동작합니다.
  * 유사 동문 상세 화면에서 전공 정보 표기 방식을 최신 온보딩 항목과 일치시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->