### PR TITLE
Fix(#62): 카드 뽑기 직무 여러 개 고려하도록 변경

### DIFF
--- a/src/main/kotlin/com/zighang/card/facade/CardFacade.kt
+++ b/src/main/kotlin/com/zighang/card/facade/CardFacade.kt
@@ -8,6 +8,7 @@ import com.zighang.core.exception.DomainException
 import com.zighang.core.exception.GlobalErrorCode
 import com.zighang.core.infrastructure.CustomUserDetails
 import com.zighang.jobposting.service.JobPostingService
+import com.zighang.member.service.JobRoleService
 import com.zighang.member.service.MemberService
 import com.zighang.member.service.OnboardingService
 import com.zighang.scrap.service.ScrapService
@@ -21,6 +22,7 @@ class CardFacade(
     private val onboardingService: OnboardingService,
     private val jobPostingService: JobPostingService,
     private val scrapService: ScrapService,
+    private val jobRoleService: JobRoleService
 ) {
     @Value("\${scrap.count_limit}")
     private lateinit var limitScrapCount: String
@@ -38,8 +40,9 @@ class CardFacade(
         val onboarding = onboardingService.getById(member.onboardingId!!)
         val jobCategory = onboarding.jobCategory
 
-        val jobRole = "생산" // Todo 직무 여러 개도 고려하도록 수정
-        val top3JobPosting = jobPostingService.top3ByJob(jobCategory, jobRole)
+        val jobRoleList = jobRoleService.findAllByOnboardingId(onboarding.id)
+            .map { jobRole -> jobRole.jobRole }
+        val top3JobPosting = jobPostingService.top3ByJob(jobCategory, jobRoleList, member.id)
 
         //이전 카드 초기화
         cardService.evict(member.id)

--- a/src/main/kotlin/com/zighang/jobposting/repository/JobPostingRepository.kt
+++ b/src/main/kotlin/com/zighang/jobposting/repository/JobPostingRepository.kt
@@ -36,14 +36,14 @@ interface JobPostingRepository : CrudRepository<JobPosting, Long> {
         from JobPosting jp
         left join Scrap s on s.jobPostingId = jp.id
         where (:depthOne is null or jp.depthOne = :depthOne)
-          and (:depthTwo is null or jp.depthTwo = :depthTwo)
+          and (:depthTwoList is null or jp.depthTwo in :depthTwoList)
         group by jp
         order by count(s.id) desc, jp.uploadDate desc, jp.id desc
         """
     )
     fun findTopJobPostingsByDepths(
         @Param("depthOne") depthOne: String?,
-        @Param("depthTwo") depthTwo: String?,
+        @Param("depthTwoList") depthTwoList: List<String>?,
         pageable: Pageable
     ): List<JobPosting>
 

--- a/src/main/kotlin/com/zighang/jobposting/service/JobPostingService.kt
+++ b/src/main/kotlin/com/zighang/jobposting/service/JobPostingService.kt
@@ -18,7 +18,7 @@ class JobPostingService(
     private val cardService: CardService,
     private val jobAnalysisEventProducer: JobAnalysisEventProducer
 ) {
-    fun top3ByJob(depthOne: String?, depthTwo: String?, memberId: Long): List<CardRedis> {
+    fun top3ByJob(depthOne: String?, depthTwo: List<String>, memberId: Long): List<CardRedis> {
 
         val page3 = PageRequest.of(0, 3)
 

--- a/src/main/kotlin/com/zighang/member/repository/JobRoleRepository.kt
+++ b/src/main/kotlin/com/zighang/member/repository/JobRoleRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface JobRoleRepository : JpaRepository<JobRole, Long> {
     fun deleteByOnboardingId(onboardingId : Long)
+    fun findByOnboardingId(onboardingId: Long) : List<JobRole>
 }

--- a/src/main/kotlin/com/zighang/member/service/JobRoleService.kt
+++ b/src/main/kotlin/com/zighang/member/service/JobRoleService.kt
@@ -1,0 +1,16 @@
+package com.zighang.member.service
+
+import com.zighang.member.entity.JobRole
+import com.zighang.member.repository.JobRoleRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class JobRoleService(
+    private val jobRoleRepository: JobRoleRepository
+) {
+    @Transactional(readOnly = true)
+    fun findAllByOnboardingId(onboardingId : Long) : List<JobRole> {
+        return jobRoleRepository.findByOnboardingId(onboardingId)
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 직무를 여러개 받을 수 있게 변경되어서 카드 뽑을 때도 직무 여러 개 고려하도록 변경
---

## ✏️ 관련 이슈
#62 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 온보딩에서 선택한 여러 직무를 기반으로 추천 카드가 생성됩니다.
  - 상위 3개 채용 카드가 복수 직무를 반영해 제공됩니다.
- 개선
  - 직무 필터가 다중 선택을 지원하여 추천 결과의 관련성과 다양성이 향상되었습니다.
  - 사용자 컨텍스트를 반영해 카드 노출 품질이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->