### PR TITLE
fix(#78) : 온보딩시 member에 온보딩 테이블이 매핑안되는 에러를 해결한다.

### DIFF
--- a/src/main/kotlin/com/zighang/member/facade/MemberFacade.kt
+++ b/src/main/kotlin/com/zighang/member/facade/MemberFacade.kt
@@ -15,6 +15,6 @@ class MemberFacade(
     @Transactional
     fun onboarding(customUserDetails: CustomUserDetails, onboardingRequest: OnboardingRequest) {
         val member = memberService.getById(customUserDetails.getId())
-        onboardingService.upsertOnboarding(member.onboardingId, onboardingRequest)
+        onboardingService.upsertOnboarding(member, member.onboardingId, onboardingRequest)
     }
 }

--- a/src/main/kotlin/com/zighang/member/service/OnboardingService.kt
+++ b/src/main/kotlin/com/zighang/member/service/OnboardingService.kt
@@ -4,6 +4,7 @@ import com.zighang.core.exception.DomainException
 import com.zighang.core.exception.GlobalErrorCode
 import com.zighang.member.dto.request.OnboardingRequest
 import com.zighang.member.entity.JobRole
+import com.zighang.member.entity.Member
 import com.zighang.member.entity.Onboarding
 import com.zighang.member.entity.value.School
 import com.zighang.member.repository.JobRoleRepository
@@ -28,15 +29,18 @@ class OnboardingService(
     }
 
     @Transactional
-    fun upsertOnboarding(onboardingId: Long?, onboardingRequest: OnboardingRequest) {
+    fun upsertOnboarding(member : Member, onboardingId: Long?, onboardingRequest: OnboardingRequest) {
         val onboarding = if (onboardingId == null) {
-            Onboarding.create(
+            val newOnboarding = Onboarding.create(
                 jobCategory = onboardingRequest.jobCategory,
                 careerYear = onboardingRequest.careerYear,
                 region = onboardingRequest.region,
                 school = School.fromSchoolName(onboardingRequest.school),
                 major = onboardingRequest.major
-            ).let(onboardingRepository::save)
+            )
+            onboardingRepository.save(newOnboarding)
+            member.completeOnboarding(newOnboarding)
+            newOnboarding
         } else {
             val found = onboardingRepository.findById(onboardingId)
                 .orElseThrow { NoSuchElementException("Onboarding not found: $onboardingId") }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 온보딩시 member에 온보딩 테이블이 매핑안되는 에러를 해결
---

## ✏️ 관련 이슈
#78 
