### PR TITLE
Fix(#81): 모바일 페이지네이션 대응을 위한 param 추가

### DIFF
--- a/src/main/kotlin/com/zighang/scrap/presentation/controller/AlumniController.kt
+++ b/src/main/kotlin/com/zighang/scrap/presentation/controller/AlumniController.kt
@@ -51,7 +51,8 @@ class AlumniController(
     @GetMapping("/similar/scraps")
     override fun getScrappedJobPostingsBySimilarUsersController(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails,
-        @RequestParam page: Int
+        @RequestParam page: Int,
+        @RequestParam(required = false, defaultValue = "false") isMobile: Boolean
     ) : ResponseEntity<RestResponse<PageResponse<AlumniSimiliarJobPostingResponseDto>>> {
 
         val safePage = if (page < 0) 0 else page
@@ -60,7 +61,7 @@ class AlumniController(
             RestResponse<PageResponse<AlumniSimiliarJobPostingResponseDto>>(
                 PageResponse.from(
                     alumniService.getScrappedJobPostingsBySimilarUsers(
-                        customUserDetails, safePage
+                        customUserDetails, safePage, isMobile
                     )
                 )
             )

--- a/src/main/kotlin/com/zighang/scrap/presentation/swagger/AlumniSwagger.kt
+++ b/src/main/kotlin/com/zighang/scrap/presentation/swagger/AlumniSwagger.kt
@@ -40,6 +40,7 @@ interface AlumniSwagger {
     fun getScrappedJobPostingsBySimilarUsersController(
         @AuthenticationPrincipal customUserDetails: CustomUserDetails,
         @RequestParam page: Int,
+        @RequestParam(required = false, defaultValue = "false") isMobile: Boolean,
     ): ResponseEntity<RestResponse<PageResponse<AlumniSimiliarJobPostingResponseDto>>>
 
     @Operation(

--- a/src/main/kotlin/com/zighang/scrap/service/AlumniService.kt
+++ b/src/main/kotlin/com/zighang/scrap/service/AlumniService.kt
@@ -128,7 +128,8 @@ class AlumniService(
     @Transactional(readOnly = true)
     fun getScrappedJobPostingsBySimilarUsers(
         customUserDetails: CustomUserDetails,
-        page: Int
+        page: Int,
+        isMobile: Boolean
     ) : Page<AlumniSimiliarJobPostingResponseDto> {
 
         val onboarding = getMemberInfo(customUserDetails).onboardingId?.let {
@@ -143,7 +144,7 @@ class AlumniService(
         val jobPostingsPage = jobPostingRepository.findAllScrappedJobPostingsBySimilarUsers(
             onboarding.school,
             jobRole,
-            PageRequest.of(page, 6)
+            PageRequest.of(page, if(isMobile) 3 else 6)
         )
 
         return jobPostingsPage.map { jobPosting ->


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
모바일 페이지네이션 대응을 위해 param 추가
---

## ✏️ 관련 이슈
#81 

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 스크랩한 유사 구인 목록 조회에 선택적 isMobile 쿼리 파라미터 추가.
  - isMobile=true일 때 페이지당 3개, 기본(false)일 때 6개 항목 제공.
  - 기본값이 false이므로 기존 사용자 흐름은 그대로 유지.

- 문서
  - API 문서/스웨거에 isMobile 파라미터 및 페이지 사이즈 동작 반영.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->