### PR TITLE
fix(#92) : 온보딩 수정 (경력 2개 가져오게)  [아직 머지하지는 말기]

### DIFF
--- a/src/main/kotlin/com/zighang/jobposting/repository/JobPostingRepository.kt
+++ b/src/main/kotlin/com/zighang/jobposting/repository/JobPostingRepository.kt
@@ -26,15 +26,13 @@ WHERE (
 )
 AND ( :excludedEmpty = true OR jp.id NOT IN (:excludedIds) )
 AND jp.upload_date >= :dateLimit
-AND (
-      (:career = 0 AND ( (jp.min_career = 0 AND jp.max_career >= 0) OR jp.min_career = -1 ))
-   OR (:career > 0 AND ( ((jp.min_career <= :career AND jp.max_career >= :career) AND jp.min_career != 0) OR jp.min_career = -1 ))
-)
+AND ((jp.min_career = -1) OR (jp.min_career <= :maxCareer AND jp.max_career >= :minCareer) )
 LIMIT 1
 """, nativeQuery = true)
     fun findRecentByRolesAndCareerExcluding(
         @Param("role") role: String,
-        @Param("career") career: Int,
+        @Param("maxCareer") maxCareer: Int,
+        @Param("minCareer") minCareer: Int,
         @Param("excludedIds") excludedIds: Set<Long>,
         @Param("excludedEmpty") excludedEmpty: Boolean,
         @Param("dateLimit") dateLimit: LocalDateTime,
@@ -50,17 +48,15 @@ WHERE (
     OR jp.depth_two LIKE CONCAT('%,', :role)
 )
 AND ( :excludedEmpty = true OR jp.id NOT IN (:excludedIds) )
-AND (
-      (:career = 0 AND ( (jp.min_career = 0 AND jp.max_career >= 0) OR jp.min_career = -1 ))
-   OR (:career > 0 AND ( (jp.min_career <= :career AND jp.max_career >= :career) OR jp.min_career = -1 ))
-)
+AND ((jp.min_career = -1) OR (jp.min_career <= :maxCareer AND jp.max_career >= :minCareer) )
 AND jp.apply_count <= 3
 LIMIT 1
 """, nativeQuery = true
     )
     fun findOneByRolesAndCareerExcludingOrderedByApplyCount(
         @Param("role") role: String,
-        @Param("career") career: Int,
+        @Param("maxCareer") maxCareer: Int,
+        @Param("minCareer") minCareer: Int,
         @Param("excludedIds") excludedIds: Set<Long>,
         @Param("excludedEmpty") excludedEmpty: Boolean,
     ): JobPosting?
@@ -76,16 +72,14 @@ WHERE (
     OR jp.depth_two LIKE CONCAT('%,', :role, ',%')
 )
 AND ( :excludedEmpty = true OR jp.id NOT IN (:excludedIds) )
-AND (
-      (:career = 0 AND ( (jp.min_career = 0 AND jp.max_career >= 0) OR jp.min_career = -1 ))
-   OR (:career > 0 AND ( (jp.min_career <= :career AND jp.max_career >= :career) OR jp.min_career = -1 ))
-)
+AND ((jp.min_career = -1) OR (jp.min_career <= :maxCareer AND jp.max_career >= :minCareer) )
 AND jp.view_count <= 500
 LIMIT 1
 """, nativeQuery = true)
     fun findOneByRolesAndCareerExcludingOrderedByViewCount(
         @Param("role") role: String,
-        @Param("career") career: Int,
+        @Param("maxCareer") maxCareer: Int,
+        @Param("minCareer") minCareer: Int,
         @Param("excludedIds") excludedIds: Set<Long>,
         @Param("excludedEmpty") excludedEmpty: Boolean,
     ): JobPosting?

--- a/src/main/kotlin/com/zighang/jobposting/service/JobPostingService.kt
+++ b/src/main/kotlin/com/zighang/jobposting/service/JobPostingService.kt
@@ -33,12 +33,14 @@ class JobPostingService(
 
     fun filterByCareerAndJobRoleAndLowestView(member : Member, depthTwo: List<String>, onboarding: Onboarding) : CardRedis {
         val excludedIds = cardService.getServedIds(member.id)
-        val myCareer = onboarding.careerYear.year
+        val maxMyCareer = onboarding.maxCareerYear.year
+        val minMyCareer = onboarding.minCareerYear.year
         val shuffledDepthTwo = depthTwo.shuffled()
         for(sdt in shuffledDepthTwo) {
             val firstTry = jobPostingRepository.findOneByRolesAndCareerExcludingOrderedByViewCount(
                 role = sdt,
-                career = myCareer,
+                maxCareer = maxMyCareer,
+                minCareer = minMyCareer,
                 excludedIds = excludedIds,
                 excludedEmpty = excludedIds.isEmpty()
             )
@@ -52,12 +54,14 @@ class JobPostingService(
 
     fun filterByCareerAndJobRoleAndLowestApply(member: Member, depthTwo: List<String>, onboarding: Onboarding) : CardRedis {
         val excludedIds = cardService.getServedIds(member.id)
-        val myCareer = onboarding.careerYear.year
+        val maxMyCareer = onboarding.maxCareerYear.year
+        val minMyCareer = onboarding.minCareerYear.year
         val shuffledDepthTwo = depthTwo.shuffled()
         for(sdt in shuffledDepthTwo) {
             val firstTry = jobPostingRepository.findOneByRolesAndCareerExcludingOrderedByApplyCount(
                 role = sdt,
-                career = myCareer,
+                maxCareer = maxMyCareer,
+                minCareer = minMyCareer,
                 excludedIds = excludedIds,
                 excludedEmpty = excludedIds.isEmpty()
             )
@@ -72,12 +76,14 @@ class JobPostingService(
     fun filterByCareerAndJobRoleAndLatest(member: Member, depthTwo: List<String>, onboarding: Onboarding) : CardRedis {
         val dataLimit = LocalDateTime.now().minusMonths(2)
         val excludedIds = cardService.getServedIds(member.id)
-        val myCareer = onboarding.careerYear.year
+        val maxMyCareer = onboarding.maxCareerYear.year
+        val minMyCareer = onboarding.minCareerYear.year
         val shuffledDepthTwo = depthTwo.shuffled()
         for(sdt in shuffledDepthTwo) {
             val firstTry = jobPostingRepository.findRecentByRolesAndCareerExcluding(
                 role = sdt,
-                career = myCareer,
+                maxCareer = maxMyCareer,
+                minCareer = minMyCareer,
                 excludedIds = excludedIds,
                 excludedEmpty =  excludedIds.isEmpty(),
                 dateLimit = dataLimit

--- a/src/main/kotlin/com/zighang/member/dto/MemberDto.kt
+++ b/src/main/kotlin/com/zighang/member/dto/MemberDto.kt
@@ -44,7 +44,9 @@ data class MemberInfo (
 data class OnboardingInfo (
     val jobCategory: String,
 
-    val careerYear: Int,
+    val maxCareerYear: Int,
+
+    val minCareerYear : Int,
 
     val region: String,
 
@@ -56,7 +58,8 @@ data class OnboardingInfo (
         fun create(onboarding: Onboarding): OnboardingInfo{
             return OnboardingInfo(
                 onboarding.jobCategory,
-                onboarding.careerYear.year,
+                onboarding.maxCareerYear.year,
+                onboarding.minCareerYear.year,
                 onboarding.region.regionName,
                 onboarding.school.schoolName,
                 onboarding.major

--- a/src/main/kotlin/com/zighang/member/dto/request/OnboardingRequest.kt
+++ b/src/main/kotlin/com/zighang/member/dto/request/OnboardingRequest.kt
@@ -10,7 +10,7 @@ data class OnboardingRequest(
     @Schema(description = "직무", example = "[\"백엔드\", \"프론트엔드\"]")
     val jobRole: List<String>,
 
-    @Schema(description = "연차", example = "YEAR_0(0),\n" +
+    @Schema(description = "최소 연차", example = "YEAR_0(0),\n" +
             "    YEAR_1(1),\n" +
             "    YEAR_2(2),\n" +
             "    YEAR_3(3),\n" +
@@ -21,7 +21,20 @@ data class OnboardingRequest(
             "    YEAR_8(8),\n" +
             "    YEAR_9(9),\n" +
             "    YEAR_10_PLUS(10),")
-    val careerYear: CareerYear,
+    val minCareerYear: CareerYear,
+
+    @Schema(description = "최대 연차", example = "YEAR_0(0),\n" +
+            "    YEAR_1(1),\n" +
+            "    YEAR_2(2),\n" +
+            "    YEAR_3(3),\n" +
+            "    YEAR_4(4),\n" +
+            "    YEAR_5(5),\n" +
+            "    YEAR_6(6),\n" +
+            "    YEAR_7(7),\n" +
+            "    YEAR_8(8),\n" +
+            "    YEAR_9(9),\n" +
+            "    YEAR_10_PLUS(10),")
+    val maxCareerYear: CareerYear,
 
     @Schema(description = "지역", example = "SEOUL(서울),\n" +
             "    GYEONGGI(경기),\n" +

--- a/src/main/kotlin/com/zighang/member/entity/Onboarding.kt
+++ b/src/main/kotlin/com/zighang/member/entity/Onboarding.kt
@@ -15,8 +15,12 @@ class Onboarding (
     var jobCategory : String,
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "career_year", nullable = false)
-    var careerYear : CareerYear,
+    @Column(name = "max_career_year", nullable = false)
+    var maxCareerYear : CareerYear,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "min_career_year", nullable = false)
+    var minCareerYear : CareerYear,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "region", nullable = false)
@@ -32,14 +36,16 @@ class Onboarding (
     companion object {
         fun create(
             jobCategory: String,
-            careerYear: CareerYear,
+            maxCareerYear: CareerYear,
+            minCareerYear: CareerYear,
             region: Region,
             school: School,
             major: String
         ): Onboarding {
             return Onboarding(
                 jobCategory = jobCategory,
-                careerYear = careerYear,
+                maxCareerYear = maxCareerYear,
+                minCareerYear = minCareerYear,
                 region = region,
                 school = school,
                 major = major
@@ -49,13 +55,15 @@ class Onboarding (
 
     fun update(
         jobCategory: String,
-        careerYear: CareerYear,
+        maxCareerYear: CareerYear,
+        minCareerYear: CareerYear,
         region: Region,
         school: School,
         major: String
     ) {
         this.jobCategory = jobCategory
-        this.careerYear = careerYear
+        this.maxCareerYear = maxCareerYear
+        this.minCareerYear = minCareerYear
         this.region = region
         this.school = school
         this.major = major

--- a/src/main/kotlin/com/zighang/member/service/OnboardingService.kt
+++ b/src/main/kotlin/com/zighang/member/service/OnboardingService.kt
@@ -33,7 +33,8 @@ class OnboardingService(
         val onboarding = if (onboardingId == null) {
             val newOnboarding = Onboarding.create(
                 jobCategory = onboardingRequest.jobCategory,
-                careerYear = onboardingRequest.careerYear,
+                maxCareerYear = onboardingRequest.maxCareerYear,
+                minCareerYear = onboardingRequest.minCareerYear,
                 region = onboardingRequest.region,
                 school = School.fromSchoolName(onboardingRequest.school),
                 major = onboardingRequest.major
@@ -47,7 +48,8 @@ class OnboardingService(
 
             found.update(
                 jobCategory = onboardingRequest.jobCategory,
-                careerYear = onboardingRequest.careerYear,
+                maxCareerYear = onboardingRequest.maxCareerYear,
+                minCareerYear = onboardingRequest.minCareerYear,
                 region = onboardingRequest.region,
                 school = School.fromSchoolName(onboardingRequest.school),
                 major = onboardingRequest.major


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 온보딩 경력 최소, 최대로 받아오게 수정
- 카드 필터링도 그거에 맞게 수정

---

## ✏️ 관련 이슈
#92 

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 온보딩에서 단일 연차 대신 최소/최대 연차 범위를 설정할 수 있습니다.
  * 채용 공고 추천(최신/조회수/지원수)이 연차 범위를 반영해 정확도가 향상되었습니다.
  * 일부 추천에서는 지원 수가 적은 공고를 우선 노출해 초기 공고 탐색이 쉬워졌습니다.
* 문서화
  * API 요청 필드 careerYear가 minCareerYear와 maxCareerYear로 변경되었으며, 설명 및 예시가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->