### PR TITLE
Fix: 공고 상세보기 전달시 저장 여부를 함께 리턴하게한다.

### DIFF
--- a/src/main/kotlin/com/zighang/jobposting/dto/response/JobPostingDetailResponseDto.kt
+++ b/src/main/kotlin/com/zighang/jobposting/dto/response/JobPostingDetailResponseDto.kt
@@ -45,6 +45,9 @@ data class JobPostingDetailResponseDto(
 
     @Schema(description = "마감일", example = "상시 or 9월 18일 23:00 마감")
     val expiredDate: String?,
+
+    @Schema(description = "해당 공고 스크랩 여부", example = "true")
+    val isSaved: Boolean
 ) {
 
 }

--- a/src/main/kotlin/com/zighang/jobposting/presentation/controller/JobPostingController.kt
+++ b/src/main/kotlin/com/zighang/jobposting/presentation/controller/JobPostingController.kt
@@ -56,11 +56,12 @@ class JobPostingController(
 
     @GetMapping("{postingId}")
     fun getDetailOfPosting(
+        @AuthenticationPrincipal customUserDetails: CustomUserDetails?,
         @PathVariable postingId: Long,
     ) : ResponseEntity<RestResponse<JobPostingDetailResponseDto>> {
         return ResponseEntity.ok(
             RestResponse<JobPostingDetailResponseDto>(
-                jobPostingService.getOneJobPosting(postingId)
+                jobPostingService.getOneJobPosting(postingId, customUserDetails)
             )
         )
     }

--- a/src/main/kotlin/com/zighang/scrap/repository/ScrapRepository.kt
+++ b/src/main/kotlin/com/zighang/scrap/repository/ScrapRepository.kt
@@ -14,6 +14,8 @@ interface ScrapRepository : JpaRepository<Scrap, Long> {
 
     fun findByIdAndMemberId(id : Long, memberId : Long) : Scrap?
 
+    fun existsByJobPostingIdAndMemberId(jobPostingId: Long, memberId : Long) : Boolean
+
     fun findByMemberIdIn(memberIdList: List<Long>): List<Scrap>
 
     fun findByMemberId(memberId: Long): List<Scrap>


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 작업한 내용 1
- 작업한 내용 2

---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

ex)
- Fixes : #00 (수정중인 이슈)
- Resolves : #100 (무슨 이슈를 해결했는지)
- Ref : #00 #01 (참고할 이슈)
- Related to : #00 #01 (해당 커밋과 관련)

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 뉴 기능
  * 채용공고 상세 화면에 스크랩 여부 표시가 추가되었습니다. 로그인한 사용자는 자신이 스크랩한 공고인지 즉시 확인할 수 있습니다.
  * 미로그인 상태에서는 스크랩되지 않은 상태로 표시됩니다.
  * 표시 방식은 상세 정보의 다른 내용에 영향을 주지 않으며, 추가적인 조작 없이 자동으로 반영됩니다.
  * 사용자별 개인화된 상태 표기로 탐색 편의성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->