### PR TITLE
fix(#110) : 스크랩 중복시 에러 뱉게 수정한다.

### DIFF
--- a/src/main/kotlin/com/zighang/core/exception/GlobalErrorCode.kt
+++ b/src/main/kotlin/com/zighang/core/exception/GlobalErrorCode.kt
@@ -25,7 +25,8 @@ enum class GlobalErrorCode(
     NOT_EXIST_MEMBER_CARD(HttpStatus.BAD_REQUEST, "이 멤버는 카드를 지니고 있지 않습니다. 카드 갱신/생성을 하세요"),
     NOT_FOUND_CARD(HttpStatus.NOT_FOUND, "해당 카드 공고는 존재하지 않습니다."),
     LIMIT_CARD(HttpStatus.BAD_REQUEST, "공고 스크랩 수가 부족합니다."),
-    INVALID_POSITION_CARD(HttpStatus.BAD_REQUEST, "잘못된 카드 위치입니다.");
+    INVALID_POSITION_CARD(HttpStatus.BAD_REQUEST, "잘못된 카드 위치입니다."),
+    ALREADY_EXIST_SCRAP(HttpStatus.BAD_REQUEST, "이미 스크랩된 공고입니다.");
 
     override fun toException(): DomainException {
         return DomainException(this)


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 중복 스크랩 시 에러를 뱉게 수정한다.

---

## ✏️ 관련 이슈
#110 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 중복 스크랩 시 “이미 스크랩된 공고입니다.” 오류를 명확히 안내하는 새 오류 코드를 추가했습니다.
- 버그 수정
  - 동일 공고를 이미 스크랩한 경우, 추가 스크랩/업데이트가 되지 않도록 검증을 강화해 중복 저장을 방지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->