### PR TITLE
Fix(#114) : 스크랩 조회 시 마감된 공고는 후순위로두고 스크랩 최신순으로 정렬해서 준다.

### DIFF
--- a/src/main/kotlin/com/zighang/scrap/repository/ScrapRepository.kt
+++ b/src/main/kotlin/com/zighang/scrap/repository/ScrapRepository.kt
@@ -8,7 +8,27 @@ import org.springframework.data.jpa.repository.Query
 import java.util.*
 
 interface ScrapRepository : JpaRepository<Scrap, Long> {
-    fun findAllByMemberId(memberId : Long, pageable: Pageable) : Page<Scrap>
+
+    @Query(
+        value = """
+        SELECT scrap.*
+        FROM scrap
+        JOIN job_posting ON job_posting.id = scrap.posting_id
+        WHERE scrap.member_id = :memberId
+        ORDER BY
+          CASE WHEN job_posting.recruitment_end_date < CURDATE() THEN 1 ELSE 0 END,
+          scrap.created_at DESC,
+          scrap.id DESC
+        """,
+        countQuery = """
+        SELECT COUNT(*)
+        FROM scrap 
+        JOIN job_posting ON job_posting.id = scrap.posting_id
+        WHERE scrap.member_id = :memberId
+        """,
+        nativeQuery = true
+    )
+    fun findAllByMemberId(memberId: Long, pageable: Pageable) : Page<Scrap>
 
     fun findByJobPostingIdAndMemberId(jobPostingId : Long, memberId : Long) : Scrap?
 


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

-  마감된 공고가 후순위로 빠지도록 구현

---

## ✏️ 관련 이슈
#114 