### PR TITLE
fix(#118) : 열린 카드 조회시에도 scrapId 주기 

### DIFF
--- a/src/main/kotlin/com/zighang/card/dto/CardJobPosting.kt
+++ b/src/main/kotlin/com/zighang/card/dto/CardJobPosting.kt
@@ -22,7 +22,7 @@ data class CardJobPosting(
     @Schema(description = "스크랩 여부", example = "true")
     var isScrap : Boolean,
     @Schema(description = "스크랩 아이디", example = "1")
-    val scrapId: Long?
+    var scrapId: Long?
 ) {
     companion object {
         fun create(

--- a/src/main/kotlin/com/zighang/card/service/CardService.kt
+++ b/src/main/kotlin/com/zighang/card/service/CardService.kt
@@ -214,8 +214,9 @@ class CardService(
             .filter { it.openDateTime != null && !it.openDateTime!!.isBefore(cutoff) && !it.openDateTime!!.isAfter(now) }
             .sortedByDescending { it.openDateTime } // 최신순
             .map {
-                val isScrap = scrapService.isScrap(memberId, it.cardJobPosting!!.jobPostingId)
-                it.cardJobPosting!!.isScrap = isScrap
+                val scrap = scrapService.findByMemberIdAndJobPostingId(memberId, it.jobPostingId)
+                it.cardJobPosting!!.isScrap = scrap.isPresent
+                it.cardJobPosting!!.scrapId = scrap.map { it.id }.orElse(null)
                 CardContentResponse.from(it) }
             .toList()
     }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 열린 카드 오픈 시에도 scrap Id 담기

---

## ✏️ 관련 이슈
#118 
