### PR TITLE
Fix(#121): 순위 변화 절댓값으로 뜨도록 변경

### DIFF
--- a/src/main/kotlin/com/zighang/scrap/dto/response/alumni/AlumniTop3JobPostingScrapResponseDto.kt
+++ b/src/main/kotlin/com/zighang/scrap/dto/response/alumni/AlumniTop3JobPostingScrapResponseDto.kt
@@ -7,6 +7,7 @@ import com.zighang.jobposting.util.getCareer
 import com.zighang.jobposting.util.getWorkType
 import com.zighang.scrap.util.dDayFactory
 import io.swagger.v3.oas.annotations.media.Schema
+import kotlin.math.abs
 
 data class AlumniTop3JobPostingScrapResponseDto(
     @Schema(description = "공고 식별자", example = "1")
@@ -59,7 +60,7 @@ data class AlumniTop3JobPostingScrapResponseDto(
                 dDayFactory(jobPosting),
                 isSaved = isSaved,
                 scrapId = scrapId,
-                jobPosting.lastRank - jobPosting.currentRank,
+                abs(jobPosting.lastRank - jobPosting.currentRank),
                 changeRankStatus =
                     if (jobPosting.lastRank == 0) RankChange.NEW.name else jobPosting.rankChange.name
             )


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 작업한 내용 1
- 작업한 내용 2

---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

ex)
- Fixes : #00 (수정중인 이슈)
- Resolves : #100 (무슨 이슈를 해결했는지)
- Ref : #00 #01 (참고할 이슈)
- Related to : #00 #01 (해당 커밋과 관련)

---

## 🎸 기타 사항 or 추가 코멘트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 없음
- 버그 수정
  - 동문 상위 3개 채용공고 스크랩의 순위 변동값이 음수로 표시되던 문제를 수정했습니다. 이제 변동 폭을 절대값으로 일관되게 표시하여 해석이 명확해졌습니다(예: 2단계).
- 개선/리팩터
  - 없음
- 문서
  - 없음
- 테스트
  - 없음
- 유지보수/기타
  - 없음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->